### PR TITLE
Fixes #416 create population should not return derived parameters

### DIFF
--- a/R/create-individual.R
+++ b/R/create-individual.R
@@ -73,7 +73,7 @@ createIndividualCharacteristics <- function(
                                             species,
                                             population = NULL,
                                             gender = NULL,
-                                            weight,
+                                            weight = NULL,
                                             weightUnit = "kg",
                                             height = NULL,
                                             heightUnit = "cm",
@@ -90,7 +90,7 @@ createIndividualCharacteristics <- function(
   validateIsString(species)
   validateIsString(population, nullAllowed = TRUE)
   validateIsString(gender, nullAllowed = TRUE)
-  validateIsNumeric(weight)
+  validateIsNumeric(weight, nullAllowed = TRUE)
   validateIsString(weightUnit)
   validateIsNumeric(height, nullAllowed = TRUE)
   validateIsString(heightUnit)

--- a/R/create-population.R
+++ b/R/create-population.R
@@ -42,7 +42,7 @@ createPopulation <- function(populationCharacteristics) {
   for (derivedParameterPath in individual$derivedParameters$paths) {
     if (population$has(derivedParameterPath)) {
       derivedParameters[[derivedParameterPath]] <- population$getParameterValues(derivedParameterPath)
-      rClr::clrCall(population$ref, "Remove", derivedParameterPath)
+      population$remove(derivedParameterPath)
     }
   }
 

--- a/R/create-population.R
+++ b/R/create-population.R
@@ -17,13 +17,12 @@ createPopulation <- function(populationCharacteristics) {
 
   individualCharacteristics <- NULL
 
-  #NOTE THIS IS A WORKAROUND UNTIL THE CODE IN PKSIM IS UPDATED
+  # NOTE THIS IS A WORKAROUND UNTIL THE CODE IN PKSIM IS UPDATED
   if (populationCharacteristics$species == Species$Human) {
     # create an individual with similar properites Species and population. WEIGHT AND AGE DO NOT MATTER as long as we can create an invidiual
     individualCharacteristics <- ospsuite::createIndividualCharacteristics(
       species = populationCharacteristics$species,
       population = populationCharacteristics$population,
-      weight = 70,
       age = 30
     )
   }
@@ -32,17 +31,32 @@ createPopulation <- function(populationCharacteristics) {
     individualCharacteristics <- ospsuite::createIndividualCharacteristics(
       species = populationCharacteristics$species,
       population = populationCharacteristics$population,
-      weight = populationCharacteristics$weightMin
     )
   }
 
   individual <- createIndividual(individualCharacteristics = individualCharacteristics)
 
   derivedParameters <- list()
+
+  # Even though those parameters are derived parmaeters, we keep them in the population for consistency purpose with the PKSim export.
+  standardDerivedParametersToKeep <- c(StandardPath$Weight, StandardPath$BMI, StandardPath$BSA)
+
   for (derivedParameterPath in individual$derivedParameters$paths) {
+    if (derivedParameterPath %in% c(StandardPath$Weight, StandardPath$BMI, StandardPath$BSA)) {
+      next
+    }
+
     if (population$has(derivedParameterPath)) {
       derivedParameters[[derivedParameterPath]] <- population$getParameterValues(derivedParameterPath)
       population$remove(derivedParameterPath)
+    }
+  }
+
+  # other parameters to remvove that should not have been exported in the first place
+  standardDistributedParametersToRemove <- c(toPathString(StandardContainer$Organism, "MeanBW"), toPathString(StandardContainer$Organism, "MeanHeight"))
+  for (parameterToRemove in standardDistributedParametersToRemove) {
+    if (population$has(parameterToRemove)) {
+      population$remove(parameterToRemove)
     }
   }
 

--- a/R/dot-net-wrapper.R
+++ b/R/dot-net-wrapper.R
@@ -21,6 +21,10 @@ DotNetWrapper <- R6::R6Class(
     #' @return A new `DotNetWrapper` object.
     initialize = function(ref) {
       self$ref <- ref
+    },
+    finalize = function() {
+      # maybe dispose should be called to if available.
+      self$ref <- NULL
     }
   ),
   private = list(

--- a/R/ospsuite-env.R
+++ b/R/ospsuite-env.R
@@ -7,7 +7,7 @@ ospsuiteEnv$packageName <- "ospsuite"
 
 ospsuiteEnv$suiteName <- "Open Systems Pharmacology"
 
-ospsuiteEnv$packageVersion <- "9.0"
+ospsuiteEnv$packageVersion <- "9.1"
 
 # Reference to container task for optimization purposes only
 ospsuiteEnv$containerTask <- NULL

--- a/R/population.R
+++ b/R/population.R
@@ -69,6 +69,12 @@ Population <- R6::R6Class(
       parameterValueListFrom(rClr::clrCall(self$ref, "AllParameterValuesForIndividual", as.integer(individualId)))
     },
     #' @description
+    #' Removes the value of a parameter by path
+    #' @param parameterPath Path of the parameter values to remove
+    remove = function(parameterPath) {
+      rClr::clrCall(self$ref, "Remove", parameterPath)
+    },
+    #' @description
     #' Print the object to the console
     #' @param ... Rest arguments.
     print = function(...) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - git submodule update --init --recursive
 
 environment:
-  app_version: "9.0"
+  app_version: "9.1"
   USE_RTOOLS: true
   NOT_CRAN: true
   KEEP_VIGNETTES: true
@@ -97,8 +97,3 @@ branches:
 
 pull_requests:
   do_not_increment_build_number: true
-
-notifications:
-  - provider: Slack
-    incoming_webhook:
-      secure: 4MH9Em6TtrKalq6808dhPOqypTfYBJvVlqPaa9akNyFEAs8X080yIO8g1FLt3tNfBN4OpeBnkgrXzf7AqNKV5561x7Coux3ByGrHmsL1sCo=

--- a/man/Population.Rd
+++ b/man/Population.Rd
@@ -32,6 +32,7 @@ List of individuals used in a population simulation
 \item \href{#method-getCovariateValues}{\code{Population$getCovariateValues()}}
 \item \href{#method-getCovariateValue}{\code{Population$getCovariateValue()}}
 \item \href{#method-getParameterValuesForIndividual}{\code{Population$getParameterValuesForIndividual()}}
+\item \href{#method-remove}{\code{Population$remove()}}
 \item \href{#method-print}{\code{Population$print()}}
 }
 }
@@ -144,6 +145,23 @@ Returns all values defined in the population the invididual with id \code{indivi
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{individualId}}{Id of individual for which all values should be returned}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-remove"></a>}}
+\if{latex}{\out{\hypertarget{method-remove}{}}}
+\subsection{Method \code{remove()}}{
+Removes the value of a parameter by path
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Population$remove(parameterPath)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{parameterPath}}{Path of the parameter values to remove}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/SensitivityAnalysisRunOptions.Rd
+++ b/man/SensitivityAnalysisRunOptions.Rd
@@ -38,10 +38,7 @@ Options to be passed to the sensitivity analysis engine
 \subsection{Method \code{new()}}{
 Initialize a new instance of the class
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SensitivityAnalysisRunOptions$new(
-  numberOfCores = ospsuiteEnv$numberOfCores,
-  showProgress = ospsuiteEnv$showProgress
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SensitivityAnalysisRunOptions$new(numberOfCores = NULL, showProgress = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/SimulationRunOptions.Rd
+++ b/man/SimulationRunOptions.Rd
@@ -42,9 +42,9 @@ Default is \code{getOSPSuiteSetting("numberOfCores")}.}
 Initialize a new instance of the class
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SimulationRunOptions$new(
-  numberOfCores = getOSPSuiteSetting("numberOfCores"),
-  checkForNegativeValues = TRUE,
-  showProgress = ospsuiteEnv$showProgress
+  numberOfCores = NULL,
+  checkForNegativeValues = NULL,
+  showProgress = NULL
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/createPopulation.Rd
+++ b/man/createPopulation.Rd
@@ -11,7 +11,9 @@ createPopulation(populationCharacteristics)
 that are actually distributed parameters}
 }
 \value{
-An instance of a population object
+An list with two entries:
+The \code{population} An instance of a population object.
+The \code{derivedParameters} containing the parameter values modified indirectly by the algorithm. Those parameters are typically formula parameters.
 }
 \description{
 Creates an population using the PKSim Database

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -84,7 +84,7 @@ end
 def install_pksim()
   file_name ='setup.zip'
   appveyor_project_name = 'pk-sim'
-  branch = 'hotfix/9.1'
+  branch = 'hotfix/v9.1'
   uri = "https://ci.appveyor.com/api/projects/#{APPVEYOR_ACCOUNT_NAME}/#{appveyor_project_name}/artifacts/#{file_name}?branch=#{branch}"
   zip_package = download_file(appveyor_project_name, file_name, uri)
   msi_package = unzip_package(zip_package)

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -84,7 +84,7 @@ end
 def install_pksim()
   file_name ='setup.zip'
   appveyor_project_name = 'pk-sim'
-  branch = 'develop'
+  branch = 'hotfix/9.1'
   uri = "https://ci.appveyor.com/api/projects/#{APPVEYOR_ACCOUNT_NAME}/#{appveyor_project_name}/artifacts/#{file_name}?branch=#{branch}"
   zip_package = download_file(appveyor_project_name, file_name, uri)
   msi_package = unzip_package(zip_package)
@@ -101,7 +101,7 @@ def download_file(project_name, file_name, uri)
   FileUtils.mkdir_p download_dir
   file = File.join(download_dir, file_name)
   puts "Downloading #{file_name} from #{uri} under #{file}".light_blue
-  open(file, 'wb') do |fo| 
+  open(file, 'wb') do |fo|
     fo.print open(uri,:read_timeout => nil).read
   end
   file

--- a/tests/dev/script-create-population.R
+++ b/tests/dev/script-create-population.R
@@ -7,7 +7,9 @@ moleculeOntogeny <- MoleculeOntogeny$new(molecule = "MyMolecule", ontogeny = Sta
 
 dog <- createPopulationCharacteristics(
   species = Species$Dog,
-  numberOfIndividuals = 50
+  numberOfIndividuals = 50,
+  weightMin = 2,
+  weightMax = 5
 )
 
 print(dog)

--- a/tests/dev/script-create-population.R
+++ b/tests/dev/script-create-population.R
@@ -31,7 +31,7 @@ human <- createPopulationCharacteristics(
 print(human)
 
 result <- createPopulation(populationCharacteristics = human)
-populationHuman <- result$population
+resupopulationHuman <- result$population
 print(populationHuman)
 
 populationHuman$getParameterValues("Organism|Age")

--- a/tests/dev/script-create-population.R
+++ b/tests/dev/script-create-population.R
@@ -11,8 +11,8 @@ dog <- createPopulationCharacteristics(
 )
 
 print(dog)
-populationDog <- createPopulation(populationCharacteristics = dog)
-
+result <- createPopulation(populationCharacteristics = dog)
+populationDog <- result$population
 print(populationDog)
 
 human <- createPopulationCharacteristics(
@@ -28,7 +28,8 @@ human <- createPopulationCharacteristics(
 
 print(human)
 
-populationHuman <- createPopulation(populationCharacteristics = human)
+result <- createPopulation(populationCharacteristics = human)
+populationHuman <- result$population
 print(populationHuman)
 
 populationHuman$getParameterValues("Organism|Age")
@@ -45,8 +46,8 @@ preterm <- createPopulationCharacteristics(
   numberOfIndividuals = 50,
 )
 
-populationPreterm <- createPopulation(populationCharacteristics = preterm)
-
+result <- createPopulation(populationCharacteristics = preterm)
+populationPreterm <- result$population
 
 
 populationPreterm$allParameterPaths

--- a/tests/testthat/test-create-individual.R
+++ b/tests/testthat/test-create-individual.R
@@ -1,6 +1,6 @@
 context("createIndividual")
 
-# initPKSim("C:/projects/PK-Sim/src/PKSim/bin/Debug/net472")
+#initPKSim("C:/projects/PK-Sim/src/PKSim/bin/Debug/net472")
 
 test_that("It can create a standard dog for a given bodyweight", {
   dog <- createIndividualCharacteristics(
@@ -43,13 +43,16 @@ test_that("It throwns an error when creating a human with population missing", {
   expect_that(createIndividual(individualCharacteristics = human), throws_error())
 })
 
-test_that("It throwns an error when creating a human with weight missing", {
-  expect_that(createIndividualCharacteristics(
+test_that("It can create reating a human with weight missing", {
+  human <- createIndividualCharacteristics(
     species = Species$Human,
     population = HumanPopulation$BlackAmerican_NHANES_1997,
     age = 15,
     gender = Gender$Female
-  ), throws_error())
+  )
+
+  human_values <- createIndividual(individualCharacteristics = human)
+  expect_false(is.null((human_values)))
 })
 
 test_that("It can create a standard human for a given bodyweight with predefined ontogenies", {

--- a/tests/testthat/test-create-population.R
+++ b/tests/testthat/test-create-population.R
@@ -1,6 +1,6 @@
 context("createPopulation")
 
-initPKSim("C:/projects/PK-Sim/src/PKSim/bin/Debug/net472")
+# initPKSim("C:/projects/PK-Sim/src/PKSim/bin/Debug/net472")
 
 test_that("It can create a standard dog population", {
   dog <- createPopulationCharacteristics(

--- a/tests/testthat/test-create-population.R
+++ b/tests/testthat/test-create-population.R
@@ -1,0 +1,66 @@
+context("createPopulation")
+
+initPKSim("C:/projects/PK-Sim/src/PKSim/bin/Debug/net472")
+
+test_that("It can create a standard dog population", {
+  dog <- createPopulationCharacteristics(
+    species = Species$Dog,
+    numberOfIndividuals = 10,
+    weightMin = 2,
+    weightMax = 10
+  )
+  dogValues <- createPopulation(populationCharacteristics = dog)
+  expect_equal(dogValues$population$count, 10)
+})
+
+test_that("It can create a standard human populaiton", {
+  human <- createPopulationCharacteristics(
+    species = Species$Human,
+    population = HumanPopulation$BlackAmerican_NHANES_1997,
+    numberOfIndividuals = 10
+  )
+  human_values <- createPopulation(populationCharacteristics = human)
+  expect_equal(human_values$population$count, 10)
+})
+
+test_that("It can create a standard human populaiton with weight constraints", {
+  human <- createPopulationCharacteristics(
+    species = Species$Human,
+    population = HumanPopulation$BlackAmerican_NHANES_1997,
+    numberOfIndividuals = 10,
+    weightMin = 20,
+    weightMax = 40
+  )
+  human_values <- createPopulation(populationCharacteristics = human)
+  expect_equal(human_values$population$count, 10)
+})
+
+test_that("It throwns an error when creating a human with population missing", {
+  human <- createPopulationCharacteristics(
+    species = Species$Human,
+    numberOfIndividuals = 10,
+  )
+  expect_that(createPopulation(populationCharacteristics = human), throws_error())
+})
+
+
+test_that("It can create a standard human population  with predefined ontogenies", {
+  moleculeOntogeny1 <- MoleculeOntogeny$new(molecule = "MyMolecule1", ontogeny = StandardOntogeny$CYP3A4)
+  moleculeOntogeny2 <- MoleculeOntogeny$new(molecule = "MyMolecule2", ontogeny = StandardOntogeny$CYP2C19)
+
+  human <- createPopulationCharacteristics(
+    species = Species$Human,
+    numberOfIndividuals = 10,
+    population = HumanPopulation$BlackAmerican_NHANES_1997,
+    moleculeOntogenies = c(moleculeOntogeny1, moleculeOntogeny2)
+  )
+
+  human_values <- createPopulation(populationCharacteristics = human)
+  paths <- human_values$population$allParameterPaths
+
+  expect_true("MyMolecule1|Ontogeny factor" %in% paths)
+  expect_true("MyMolecule1|Ontogeny factor GI" %in% paths)
+
+  expect_true("MyMolecule2|Ontogeny factor" %in% paths)
+  expect_true("MyMolecule2|Ontogeny factor GI" %in% paths)
+})

--- a/tests/testthat/test-population.R
+++ b/tests/testthat/test-population.R
@@ -64,6 +64,16 @@ test_that("It can add user defined variability using values with NA", {
   expect_identical(population$getParameterValues(parameterPath), values_with_NA)
 })
 
+test_that("It can remove user defined variability", {
+  population <- loadPopulation(populationFileName)
+  parameterPath <- "Organism|MyParameterWithNA"
+  values <- c(1:10) * 2.5
+  population$setParameterValues(parameterPath, values)
+  expect_true(population$has(parameterPath))
+  population$remove(parameterPath)
+  expect_false(population$has(parameterPath))
+})
+
 test_that("It throws an exception when adding values that have the wrong number of items", {
   population <- loadPopulation(populationFileName)
   parameterPath <- "Organism|MyParameter"

--- a/tests/testthat/test-sensitivity-analysis-run-options.R
+++ b/tests/testthat/test-sensitivity-analysis-run-options.R
@@ -1,6 +1,7 @@
 context("SensitivityAnalysisRunOptions")
+
 test_that("it can create a sensitivity analysis run options by passing some null values", {
   options <- SensitivityAnalysisRunOptions$new(numberOfCores = NULL, showProgress = FALSE)
   expect_false(options$showProgress)
-  expect_equal(options$numberOfCores, 1)
+  expect_false(is.null(options$numberOfCores))
 })

--- a/vignettes/create-run-population.Rmd
+++ b/vignettes/create-run-population.Rmd
@@ -52,7 +52,8 @@ populationCharacteristics <- createPopulationCharacteristics(
 print(populationCharacteristics)
 
 # Create population from population characteristics
-myPopulation <- createPopulation(populationCharacteristics = populationCharacteristics)
+result <- createPopulation(populationCharacteristics = populationCharacteristics)
+myPopulation <- result$population
 print(myPopulation)
 ```
 


### PR DESCRIPTION
The population returned by createPopulation also contains formula parameters which is not the expected behavior
This workaround fixes the issue by returning a list with two objects
1/a population (what was returned before)
2/a list of path values to see the value of all derived parameters at TIME OF CREATION of the population

Updating the population object will obviously not update the derived parameters but at least we have a good separation of concern