### PR TITLE
temporarily disable print test under Linux (s. #435)

### DIFF
--- a/tests/testthat/test-user-defined-pk-parameter.R
+++ b/tests/testthat/test-user-defined-pk-parameter.R
@@ -2,6 +2,8 @@ context("UserDefinedPKParameter")
 
 
 test_that("It print a user defined pk parameter", {
+  skip_on_os("linux") # TODO enable again as soon as https://github.com/Open-Systems-Pharmacology/OSPSuite-R/issues/435 was fixed
+
   userDefinedPKParameter <- addUserDefinedPKParameter(name = "MyAUC", standardPKParameter = StandardPKParameter$AUC_tEnd)
   userDefinedPKParameter$startTime <- 50
   userDefinedPKParameter$endTime <- 80


### PR DESCRIPTION
disabling the "advanced-pk-parameter" test undr Linux for now (s. discussion in https://github.com/Open-Systems-Pharmacology/OSPSuite-R/issues/435)