### PR TITLE
change round brackets to square brackets in dimension names

### DIFF
--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -273,7 +273,9 @@ getUnitsEnum <- function() {
     x <- getUnitsForDimension(dimension = dimension)
     return(enum(replace(x, x == "", "Unitless")))
   })
-  names(units) <- dimensions
+  names(units) <- sapply(dimensions,function(str){
+    str <- gsub(pattern = "[(]",replacement = "[",x = str)
+    str <- gsub(pattern = "[)]",replacement = "]",x = str)})
   return(units)
 }
 


### PR DESCRIPTION
Enables intellisense in ospUnits lists such as Concentration (Mass)