### PR TITLE
remove rd docs for finalize methods

### DIFF
--- a/R/data-set.R
+++ b/R/data-set.R
@@ -16,6 +16,7 @@ DataSet <- R6::R6Class(
   inherit = DotNetWrapper,
   cloneable = FALSE,
   active = list(
+
     #' @field name The name of the DataSet
     name = function(value) {
       if (missing(value)) {
@@ -25,6 +26,7 @@ DataSet <- R6::R6Class(
     },
 
     #' @field dataRepository The underlying DataRepository object
+
     dataRepository = function(value) {
       if (missing(value)) {
         return(private$.dataRepository)
@@ -33,28 +35,35 @@ DataSet <- R6::R6Class(
     },
 
     #' @field xDimension Dimension in which the xValues are defined
+
     xDimension = function(value) {
       if (missing(value)) {
         return(private$.xColumn$dimension)
       }
       private$.setColumnDimension(private$.xColumn, value)
     },
+
     #' @field xUnit Unit in which the xValues are defined
+
     xUnit = function(value) {
       if (missing(value)) {
         return(private$.xColumn$displayUnit)
       }
       private$.setColumnUnit(private$.xColumn, value)
     },
+
     #' @field xValues Values stored in the xUnit. This field is read-only.
     #' Use `$setValues()` to change the values.
+
     xValues = function(values) {
       if (missing(values)) {
         return(private$.getColumnValues(private$.xColumn))
       }
       private$throwPropertyIsReadonly("xValues")
     },
+
     #' @field yDimension Dimension in which the yValues are defined
+
     yDimension = function(value) {
       if (missing(value)) {
         return(private$.yColumn$dimension)
@@ -65,15 +74,19 @@ DataSet <- R6::R6Class(
         private$.setColumnDimension(private$.yErrorColumn, value)
       }
     },
+
     #' @field yUnit Unit in which the yValues are defined
+
     yUnit = function(value) {
       if (missing(value)) {
         return(private$.yColumn$displayUnit)
       }
       private$.setColumnUnit(private$.yColumn, value)
     },
+
     #' @field yValues Values stored in the yUnit. This field is read-only.
     #' Use `$setValues()` to change the values.
+
     yValues = function(values) {
       if (missing(values)) {
         return(private$.getColumnValues(private$.yColumn))
@@ -82,9 +95,12 @@ DataSet <- R6::R6Class(
     },
 
     #' @field yErrorType Type of the error - geometric or arithmetic.
-    #' When changing from arithmetic to geometric error, the values are considered in as fraction (1 = 100%).
-    #' When changing from geometric to arithmetic, the values are set to the same unit as `yErrorUnit`.
+    #' When changing from arithmetic to geometric error, the values are
+    #' considered in as fraction (1 = 100%).
+    #' When changing from geometric to arithmetic, the values are set to the
+    #' same unit as `yErrorUnit`.
     #' In case no yError is defined, the value is `NULL` and cannot be changed
+
     yErrorType = function(value) {
       if (missing(value)) {
         if (is.null(private$.yErrorColumn)) {
@@ -97,9 +113,12 @@ DataSet <- R6::R6Class(
       }
       private$.setErrorType(value)
     },
-    #' @field yErrorUnit Unit in which the yErrorValues are defined. For arithmetic error, the unit must be valid
-    #' for `yDimension`. For geometric error, the unit must be valid for `Dimensionless`.
-    #' In case no yError is defined, the value is `NULL` and cannot be changed
+
+    #' @field yErrorUnit Unit in which the yErrorValues are defined. For
+    #'   arithmetic error, the unit must be valid for `yDimension`. For
+    #'   geometric error, the unit must be valid for `Dimensionless`.
+    #'   In case no yError is defined, the value is `NULL` and cannot be changed
+
     yErrorUnit = function(value) {
       if (missing(value)) {
         # Do not have to check for NULL here becase NULL$something is NULL
@@ -111,10 +130,12 @@ DataSet <- R6::R6Class(
       }
       invisible(self)
     },
+
     #' @field yErrorValues Values of error stored in the yErrorUnit unit. This field is read-only.
     #' Use `$setValues()` to change the values.
     #' In case no yError is defined, the value is `NULL` and cannot be changed.
     #' Use `$setValues()` to change the values.
+
     yErrorValues = function(values) {
       if (missing(values)) {
         if (is.null(private$.yErrorColumn)) {
@@ -125,20 +146,31 @@ DataSet <- R6::R6Class(
       }
       private$throwPropertyIsReadonly("yErrorValues")
     },
+
     #' @field molWeight Molecular weight of the yValues in g/mol
+
     molWeight = function(value) {
       if (missing(value)) {
         molWeight <- private$.yColumn$molWeight
         if (is.null(molWeight)) {
           return(NULL)
         }
-        return(toUnit(quantityOrDimension = ospDimensions$`Molecular weight`, values = molWeight, targetUnit = ospUnits$`Molecular weight`$`g/mol`))
+        return(toUnit(
+          quantityOrDimension = ospDimensions$`Molecular weight`,
+          values = molWeight,
+          targetUnit = ospUnits$`Molecular weight`$`g/mol`
+        ))
       }
 
-      private$.yColumn$molWeight <- toBaseUnit(quantityOrDimension = ospDimensions$`Molecular weight`, values = value, unit = ospUnits$`Molecular weight`$`g/mol`)
+      private$.yColumn$molWeight <- toBaseUnit(
+        quantityOrDimension = ospDimensions$`Molecular weight`,
+        values = value,
+        unit = ospUnits$`Molecular weight`$`g/mol`
+      )
     },
     #' @field LLOQ LLOQ Lower Limit Of Quantification.
     #' Value in yUnit associated with the yValues
+
     LLOQ = function(value) {
       if (missing(value)) {
         # Value in base unit
@@ -146,12 +178,25 @@ DataSet <- R6::R6Class(
         if (is.null(lloq)) {
           return(NULL)
         }
-        return(toUnit(quantityOrDimension = private$.yColumn$dimension, values = lloq, targetUnit = private$.yColumn$displayUnit))
+
+        return(
+          toUnit(
+            quantityOrDimension = private$.yColumn$dimension,
+            values = lloq,
+            targetUnit = private$.yColumn$displayUnit
+          )
+        )
       }
-      private$.yColumn$LLOQ <- toBaseUnit(quantityOrDimension = private$.yColumn$dimension, values = value, unit = private$.yColumn$displayUnit)
+
+      private$.yColumn$LLOQ <- toBaseUnit(
+        quantityOrDimension = private$.yColumn$dimension,
+        values = value,
+        unit = private$.yColumn$displayUnit
+      )
     },
 
     #' @field metaData Returns a named list of meta data defined for the data set.
+
     metaData = function(value) {
       if (missing(value)) {
         return(private$.dataRepository$metaData)
@@ -160,6 +205,7 @@ DataSet <- R6::R6Class(
     }
   ),
   public = list(
+
     #' @description
     #' Initialize a new instance of the class
     #' @param dataRepository Instance of the `DataRepository` object to wrap.
@@ -171,10 +217,12 @@ DataSet <- R6::R6Class(
     },
 
     #' @description
-    #' Adds a new entry to meta data list or changes its value if the name is already present.
+    #' Adds a new entry to meta data list or changes its value if the name is
+    #' already present.
     #'
     #' @param name Name of new meta data list entry
     #' @param value Value of new meta data list entry
+
     addMetaData = function(name, value) {
       private$.dataRepository$addMetaData(name, value)
     },
@@ -183,6 +231,7 @@ DataSet <- R6::R6Class(
     #' Removes the meta data entry in the list if one is defined with this name
     #'
     #' @param name Name of meta data entry to delete
+
     removeMetaData = function(name) {
       private$.dataRepository$removeMetaData(name)
     },
@@ -193,6 +242,7 @@ DataSet <- R6::R6Class(
     #' @param xValues xValues to use
     #' @param yValues yValues to use
     #' @param yErrorValues Optional error values associated with yValues
+
     setValues = function(xValues, yValues, yErrorValues = NULL) {
       validateIsNumeric(xValues)
       validateIsNumeric(yValues)
@@ -205,10 +255,16 @@ DataSet <- R6::R6Class(
       private$.setColumnValues(column = private$.xColumn, xValues)
       private$.setColumnValues(column = private$.yColumn, yValues)
 
-      # yError column must be removed in case yError is NULL and there is a yErrorColumn already
+      # yError column must be removed in case yError is NULL and there is a
+      # yErrorColumn already
       if (is.null(yErrorValues) && !is.null(private$.yErrorColumn)) {
         dataRepositoryTask <- getNetTask("DataRepositoryTask")
-        rClr::clrCall(dataRepositoryTask, "RemoveColumn", private$.dataRepository$ref, private$.yErrorColumn$ref)
+        rClr::clrCall(
+          dataRepositoryTask,
+          "RemoveColumn",
+          private$.dataRepository$ref,
+          private$.yErrorColumn$ref
+        )
         private$.yErrorColumn <- NULL
       }
 
@@ -221,6 +277,7 @@ DataSet <- R6::R6Class(
     #' @description
     #' Print the object to the console
     #' @param ... Rest arguments.
+
     print = function(...) {
       private$printClass()
       private$printLine("Name", self$name)
@@ -244,7 +301,11 @@ DataSet <- R6::R6Class(
     .yErrorColumn = NULL,
     .setColumnValues = function(column, values) {
       # values are set in the display unit. We need to make sure we convert them to the base unit
-      valuesInBaseUnit <- toBaseUnit(quantityOrDimension = column$dimension, values = values, unit = column$displayUnit)
+      valuesInBaseUnit <- toBaseUnit(
+        quantityOrDimension = column$dimension,
+        values = values,
+        unit = column$displayUnit
+      )
       column$values <- valuesInBaseUnit
       invisible(self)
     },
@@ -294,7 +355,11 @@ DataSet <- R6::R6Class(
       values <- private$.getColumnValues(column)
 
       dataInfo <- rClr::clrGet(column$ref, "DataInfo")
-      rClr::clrSet(dataInfo, "AuxiliaryType", rClr::clrGet("OSPSuite.Core.Domain.Data.AuxiliaryType", errorType))
+      rClr::clrSet(
+        dataInfo,
+        "AuxiliaryType",
+        rClr::clrGet("OSPSuite.Core.Domain.Data.AuxiliaryType", errorType)
+      )
 
       # Geometric to arithmetic - set to the same dimension and unit as yValues
       if (errorType == DataErrorType$ArithmeticStdDev) {
@@ -312,11 +377,25 @@ DataSet <- R6::R6Class(
     .createDataRepository = function() {
       # Create an empty data repository with a base grid and columns
       dataRepository <- DataRepository$new()
+
       # Passing time for dimension for now
-      xColumn <- DataColumn$new(rClr::clrNew("OSPSuite.Core.Domain.Data.BaseGrid", "xValues", getDimensionByName(ospDimensions$Time)))
+      xColumn <- DataColumn$new(
+        rClr::clrNew(
+          "OSPSuite.Core.Domain.Data.BaseGrid",
+          "xValues",
+          getDimensionByName(ospDimensions$Time)
+        )
+      )
 
       # Passing concentration (mass) for dimension for now
-      yColumn <- DataColumn$new(rClr::clrNew("OSPSuite.Core.Domain.Data.DataColumn", "yValues", getDimensionByName(ospDimensions$`Concentration (mass)`), xColumn$ref))
+      yColumn <- DataColumn$new(
+        rClr::clrNew(
+          "OSPSuite.Core.Domain.Data.DataColumn",
+          "yValues",
+          getDimensionByName(ospDimensions$`Concentration (mass)`),
+          xColumn$ref
+        )
+      )
 
       dataRepository$addColumn(xColumn)
       dataRepository$addColumn(yColumn)
@@ -339,7 +418,13 @@ DataSet <- R6::R6Class(
       }
 
       dataRepositoryTask <- getNetTask("DataRepositoryTask")
-      netYErrorColumn <- rClr::clrCall(dataRepositoryTask, "AddErrorColumn", private$.yColumn$ref, "yErrorValues", DataErrorType$ArithmeticStdDev)
+      netYErrorColumn <- rClr::clrCall(
+        dataRepositoryTask,
+        "AddErrorColumn",
+        private$.yColumn$ref,
+        "yErrorValues",
+        DataErrorType$ArithmeticStdDev
+      )
       private$.yErrorColumn <- DataColumn$new(netYErrorColumn)
     }
   )

--- a/R/dot-net-wrapper.R
+++ b/R/dot-net-wrapper.R
@@ -114,8 +114,6 @@ DotNetWrapper <- R6::R6Class(
     throwPropertyIsReadonly = function(propertyName) {
       stop(messages$errorPropertyReadOnly(propertyName), call. = FALSE)
     },
-    #' @description
-    #' Clears the reference to the wrapped .NET object
     finalize = function() {
       # maybe dispose should be called to if available.
       self$ref <- NULL

--- a/R/simulation-batch.R
+++ b/R/simulation-batch.R
@@ -10,8 +10,6 @@ SimulationBatch <- R6::R6Class(
   inherit = DotNetWrapper,
   private = list(
     .simulation = NULL,
-    #' @description
-    #' Clears the reference to the wrapped .NET object
     finalize = function() {
       private$.simulation <- NULL
       # SimulationBatch are disposable object and should be disposed

--- a/R/utilities-data-set.R
+++ b/R/utilities-data-set.R
@@ -65,10 +65,15 @@ saveDataSetToPKML <- function(dataSet, filePath) {
 #'
 #' @param dataSets A list of `DataSet` objects or a single `DataSet`
 #'
-#' @return DataSet objects as data.frame with columns name, xValues, yValues, yErrorValues,
-#' xDimension, xUnit, yDimension, yUnit, yErrorType, yErrorUnit, molWeight, lloq,
-#'  and a column for each meta data that is present in any `DataSet`
+#' @return
+#'
+#' DataSet objects as data.frame with columns name, xValues, yValues,
+#' yErrorValues, xDimension, xUnit, yDimension, yUnit, yErrorType, yErrorUnit,
+#' molWeight, lloq, and a column for each meta data that is present in any
+#' `DataSet`.
+#'
 #' @export
+
 dataSetToDataFrame <- function(dataSets) {
   dataSets <- c(dataSets)
   validateIsOfType(dataSets, DataSet)
@@ -86,11 +91,13 @@ dataSetToDataFrame <- function(dataSets) {
   yValues      <- .makeDataFrameColumn(dataSets, "yValues")
   yErrorValues <- .makeDataFrameColumn(dataSets, "yErrorValues")
   lloq         <- .makeDataFrameColumn(dataSets, "LLOQ")
-  df           <- data.frame(
+  # styler: on
+
+  df <- data.frame(
     name, xValues, yValues, yErrorValues, xDimension, xUnit, yDimension,
     yUnit, yErrorType, yErrorUnit, molWeight, lloq
   )
-  # styler: on
+
 
   # get all names of meta data entries from all data sets
   metaDataNames <- unique(unlist(lapply(dataSets, function(dataSets) {

--- a/R/utilities-data-set.R
+++ b/R/utilities-data-set.R
@@ -73,27 +73,30 @@ dataSetToDataFrame <- function(dataSets) {
   dataSets <- c(dataSets)
   validateIsOfType(dataSets, DataSet)
 
-  name <- .makeDataFrameColumn(dataSets, "name")
-  xUnit <- .makeDataFrameColumn(dataSets, "xUnit")
-  yUnit <- .makeDataFrameColumn(dataSets, "yUnit")
-  yErrorUnit <- .makeDataFrameColumn(dataSets, "yErrorUnit")
-  xDimension <- .makeDataFrameColumn(dataSets, "xDimension")
-  yDimension <- .makeDataFrameColumn(dataSets, "yDimension")
-  yErrorType <- .makeDataFrameColumn(dataSets, "yErrorType")
-  molWeight <- .makeDataFrameColumn(dataSets, "molWeight")
-  xValues <- .makeDataFrameColumn(dataSets, "xValues")
-  yValues <- .makeDataFrameColumn(dataSets, "yValues")
+  # styler: off
+  name         <- .makeDataFrameColumn(dataSets, "name")
+  xUnit        <- .makeDataFrameColumn(dataSets, "xUnit")
+  yUnit        <- .makeDataFrameColumn(dataSets, "yUnit")
+  yErrorUnit   <- .makeDataFrameColumn(dataSets, "yErrorUnit")
+  xDimension   <- .makeDataFrameColumn(dataSets, "xDimension")
+  yDimension   <- .makeDataFrameColumn(dataSets, "yDimension")
+  yErrorType   <- .makeDataFrameColumn(dataSets, "yErrorType")
+  molWeight    <- .makeDataFrameColumn(dataSets, "molWeight")
+  xValues      <- .makeDataFrameColumn(dataSets, "xValues")
+  yValues      <- .makeDataFrameColumn(dataSets, "yValues")
   yErrorValues <- .makeDataFrameColumn(dataSets, "yErrorValues")
-  lloq <- .makeDataFrameColumn(dataSets, "LLOQ")
-  df <- data.frame(
+  lloq         <- .makeDataFrameColumn(dataSets, "LLOQ")
+  df           <- data.frame(
     name, xValues, yValues, yErrorValues, xDimension, xUnit, yDimension,
     yUnit, yErrorType, yErrorUnit, molWeight, lloq
   )
+  # styler: on
 
   # get all names of meta data entries from all data sets
   metaDataNames <- unique(unlist(lapply(dataSets, function(dataSets) {
     names(dataSets[["metaData"]])
   }), use.names = FALSE))
+
   # add one column for each one
   for (name in metaDataNames) {
     col <- .makeDataFrameColumn(dataSets, "metaData", metaDataName = name)

--- a/R/utilities-output-selections.R
+++ b/R/utilities-output-selections.R
@@ -1,10 +1,13 @@
-
-#' @title  Adds the quantities as output into the  `simulation`. The quantities can either be specified using explicit instances or using paths.
+#' @title  Adds the quantities as output into the  `simulation`. The quantities
+#'   can either be specified using explicit instances or using paths.
 #'
-#' @param quantitiesOrPaths Quantity instances (element or vector) (typically retrieved using `getAllQuantitiesMatching`) or quantity path (element or vector) to add.
-#' @param simulation Instance of a simulation for which output selection should be updated.
+#' @param quantitiesOrPaths Quantity instances (element or vector) (typically
+#'   retrieved using `getAllQuantitiesMatching`) or quantity path (element or
+#'   vector) to add.
+#' @param simulation Instance of a simulation for which output selection should
+#'   be updated.
 #'
-#' @examples#'
+#' @examples
 #' simPath <- system.file("extdata", "simple.pkml", package = "ospsuite")
 #' sim <- loadSimulation(simPath)
 #'

--- a/R/utilities-quantity.R
+++ b/R/utilities-quantity.R
@@ -1,11 +1,18 @@
 
-#' Retrieve all quantities of a container (simulation or container instance) matching the given path criteria
+#' Retrieve all quantities of a container (simulation or container instance)
+#' matching the given path criteria
 #'
 #' @param paths A vector of strings relative to the `container`
 #' @param container A Container or Simulation used to find the parameters
-#' @seealso [loadSimulation()], [getContainer()] and [getAllContainersMatching()] to retrieve objects of type Container or Simulation
+#' @seealso [loadSimulation()], [getContainer()] and
+#'   [getAllContainersMatching()] to retrieve objects of type Container or
+#'   Simulation
 #'
-#' @return A list of quantities matching the path criteria. The list is empty if no quantity matching were found.
+#' @return
+#'
+#' A list of quantities matching the path criteria. The list is empty if no
+#' quantity matching were found.
+#'
 #' @examples
 #'
 #' simPath <- system.file("extdata", "simple.pkml", package = "ospsuite")
@@ -21,6 +28,7 @@
 #'
 #' # Returns all `Volume` quantities defined in `Organism` and all its subcontainers
 #' quantities <- getAllQuantitiesMatching("Organism|**|Volume", sim)
+#'
 #' @export
 getAllQuantitiesMatching <- function(paths, container) {
   getAllEntitiesMatching(paths, container, Quantity)
@@ -29,7 +37,9 @@ getAllQuantitiesMatching <- function(paths, container) {
 #' Retrieves the path of all quantities defined in the container and all its children
 #'
 #' @param container A Container or Simulation used to find the parameters
-#' @seealso [loadSimulation()], [getContainer()] and [getAllContainersMatching()] to retrieve objects of type Container or Simulation
+#' @seealso [loadSimulation()], [getContainer()] and
+#'   [getAllContainersMatching()] to retrieve objects of type Container or
+#'   Simulation
 #'
 #' @return An array with one entry per quantity defined in the container
 #' @examples
@@ -48,8 +58,8 @@ getAllQuantityPathsIn <- function(container) {
 #'
 #' @inherit getAllQuantitiesMatching
 #' @param path A string representing the path relative to the `container`
-#' @param stopIfNotFound Boolean. If `TRUE` (default) and no quantity exists for the given path,
-#' an error is thrown. If `FALSE`, `NULL` is returned.
+#' @param stopIfNotFound Boolean. If `TRUE` (default) and no quantity exists for
+#'   the given path, an error is thrown. If `FALSE`, `NULL` is returned.
 #'
 #' @return The `Quantity` with the given path. If the quantity for the path
 #' does not exist, an error is thrown if `stopIfNotFound` is `TRUE` (default),
@@ -68,12 +78,14 @@ getQuantity <- function(path, container, stopIfNotFound = TRUE) {
 #' Set values of quantity
 #'
 #' @param quantities A single or a list of `Quantity`
-#'
-#' @param values A numeric value that should be assigned to the quantity or a vector
-#' of numeric values, if the value of more than one quantity should be changed. Must have the same
-#' length as 'quantities'. Alternatively, the value can be a unique number. In that case, the same value will be set in all parameters
-#' @param units A string or a list of strings defining the units of the `values`. If `NULL` (default), values
-#' are assumed to be in base units. If not `NULL`, must have the same length as `quantities`.
+#' @param values A numeric value that should be assigned to the quantity or a
+#'   vector of numeric values, if the value of more than one quantity should be
+#'   changed. Must have the same length as 'quantities'. Alternatively, the
+#'   value can be a unique number. In that case, the same value will be set in
+#'   all parameters
+#' @param units A string or a list of strings defining the units of the
+#'   `values`. If `NULL` (default), values are assumed to be in base units. If
+#'   not `NULL`, must have the same length as `quantities`.
 #'
 setQuantityValues <- function(quantities, values, units = NULL) {
   # Must turn the input into a list so we can iterate through even when only
@@ -109,14 +121,17 @@ setQuantityValues <- function(quantities, values, units = NULL) {
 #' Set the values of parameters in the simulation by path
 #'
 #' @param quantityPaths A single or a list of absolute quantity path
-#' @param values A numeric value that should be assigned to the quantities or a vector
-#' of numeric values, if the value of more than one quantity should be changed. Must have the same
-#' length as 'quantityPaths'
-#' @param simulation Simulation uses to retrieve quantity instances from given paths.
-#' @param stopIfNotFound Boolean. If `TRUE` (default) and no quantity exists for the given path,
-#' an error is thrown. If `FALSE`, a warning is shown to the user
-#' @param units A string or a list of strings defining the units of the `values`. If `NULL` (default), values
-#' are assumed to be in base units. If not `NULL`, must have the same length as `quantityPaths`.
+#' @param values A numeric value that should be assigned to the quantities or a
+#'   vector of numeric values, if the value of more than one quantity should be
+#'   changed. Must have the same length as 'quantityPaths'.
+#' @param simulation Simulation uses to retrieve quantity instances from given
+#'   paths.
+#' @param stopIfNotFound Boolean. If `TRUE` (default) and no quantity exists for
+#'   the given path, an error is thrown. If `FALSE`, a warning is shown to the
+#'   user.
+#' @param units A string or a list of strings defining the units of the
+#'   `values`. If `NULL` (default), values are assumed to be in base units. If
+#'   not `NULL`, must have the same length as `quantityPaths`.
 #' @examples
 #'
 #' simPath <- system.file("extdata", "simple.pkml", package = "ospsuite")

--- a/man/DataSet.Rd
+++ b/man/DataSet.Rd
@@ -32,12 +32,15 @@ Use \verb{$setValues()} to change the values.}
 Use \verb{$setValues()} to change the values.}
 
 \item{\code{yErrorType}}{Type of the error - geometric or arithmetic.
-When changing from arithmetic to geometric error, the values are considered in as fraction (1 = 100\%).
-When changing from geometric to arithmetic, the values are set to the same unit as \code{yErrorUnit}.
+When changing from arithmetic to geometric error, the values are
+considered in as fraction (1 = 100\%).
+When changing from geometric to arithmetic, the values are set to the
+same unit as \code{yErrorUnit}.
 In case no yError is defined, the value is \code{NULL} and cannot be changed}
 
-\item{\code{yErrorUnit}}{Unit in which the yErrorValues are defined. For arithmetic error, the unit must be valid
-for \code{yDimension}. For geometric error, the unit must be valid for \code{Dimensionless}.
+\item{\code{yErrorUnit}}{Unit in which the yErrorValues are defined. For
+arithmetic error, the unit must be valid for \code{yDimension}. For
+geometric error, the unit must be valid for \code{Dimensionless}.
 In case no yError is defined, the value is \code{NULL} and cannot be changed}
 
 \item{\code{yErrorValues}}{Values of error stored in the yErrorUnit unit. This field is read-only.
@@ -95,7 +98,8 @@ A new \code{DataSet} object.
 \if{html}{\out{<a id="method-addMetaData"></a>}}
 \if{latex}{\out{\hypertarget{method-addMetaData}{}}}
 \subsection{Method \code{addMetaData()}}{
-Adds a new entry to meta data list or changes its value if the name is already present.
+Adds a new entry to meta data list or changes its value if the name is
+already present.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataSet$addMetaData(name, value)}\if{html}{\out{</div>}}
 }

--- a/man/SimulationBatch.Rd
+++ b/man/SimulationBatch.Rd
@@ -64,9 +64,6 @@ res <- runSimulationBatches(simulationBatches = list(simulationBatch1, simulatio
 \if{html}{\out{<a id="method-new"></a>}}
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
-Clears the reference to the wrapped .NET object
-
-
 Initialize a new instance of the class
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SimulationBatch$new(ref, simulation)}\if{html}{\out{</div>}}

--- a/man/addOutputs.Rd
+++ b/man/addOutputs.Rd
@@ -2,20 +2,24 @@
 % Please edit documentation in R/utilities-output-selections.R
 \name{addOutputs}
 \alias{addOutputs}
-\title{Adds the quantities as output into the  \code{simulation}. The quantities can either be specified using explicit instances or using paths.}
+\title{Adds the quantities as output into the  \code{simulation}. The quantities
+can either be specified using explicit instances or using paths.}
 \usage{
 addOutputs(quantitiesOrPaths, simulation)
 }
 \arguments{
-\item{quantitiesOrPaths}{Quantity instances (element or vector) (typically retrieved using \code{getAllQuantitiesMatching}) or quantity path (element or vector) to add.}
+\item{quantitiesOrPaths}{Quantity instances (element or vector) (typically
+retrieved using \code{getAllQuantitiesMatching}) or quantity path (element or
+vector) to add.}
 
-\item{simulation}{Instance of a simulation for which output selection should be updated.}
+\item{simulation}{Instance of a simulation for which output selection should
+be updated.}
 }
 \description{
-Adds the quantities as output into the  \code{simulation}. The quantities can either be specified using explicit instances or using paths.
+Adds the quantities as output into the  \code{simulation}. The quantities
+can either be specified using explicit instances or using paths.
 }
 \examples{
-#'
 simPath <- system.file("extdata", "simple.pkml", package = "ospsuite")
 sim <- loadSimulation(simPath)
 

--- a/man/dataSetToDataFrame.Rd
+++ b/man/dataSetToDataFrame.Rd
@@ -10,9 +10,10 @@ dataSetToDataFrame(dataSets)
 \item{dataSets}{A list of \code{DataSet} objects or a single \code{DataSet}}
 }
 \value{
-DataSet objects as data.frame with columns name, xValues, yValues, yErrorValues,
-xDimension, xUnit, yDimension, yUnit, yErrorType, yErrorUnit, molWeight, lloq,
-and a column for each meta data that is present in any \code{DataSet}
+DataSet objects as data.frame with columns name, xValues, yValues,
+yErrorValues, xDimension, xUnit, yDimension, yUnit, yErrorType, yErrorUnit,
+molWeight, lloq, and a column for each meta data that is present in any
+\code{DataSet}.
 }
 \description{
 Converts a list of \code{DataSet} objects to a data.frame

--- a/man/getAllQuantitiesMatching.Rd
+++ b/man/getAllQuantitiesMatching.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/utilities-quantity.R
 \name{getAllQuantitiesMatching}
 \alias{getAllQuantitiesMatching}
-\title{Retrieve all quantities of a container (simulation or container instance) matching the given path criteria}
+\title{Retrieve all quantities of a container (simulation or container instance)
+matching the given path criteria}
 \usage{
 getAllQuantitiesMatching(paths, container)
 }
@@ -12,10 +13,12 @@ getAllQuantitiesMatching(paths, container)
 \item{container}{A Container or Simulation used to find the parameters}
 }
 \value{
-A list of quantities matching the path criteria. The list is empty if no quantity matching were found.
+A list of quantities matching the path criteria. The list is empty if no
+quantity matching were found.
 }
 \description{
-Retrieve all quantities of a container (simulation or container instance) matching the given path criteria
+Retrieve all quantities of a container (simulation or container instance)
+matching the given path criteria
 }
 \examples{
 
@@ -32,7 +35,10 @@ quantities <- getAllQuantitiesMatching(paths, sim)
 
 # Returns all `Volume` quantities defined in `Organism` and all its subcontainers
 quantities <- getAllQuantitiesMatching("Organism|**|Volume", sim)
+
 }
 \seealso{
-\code{\link[=loadSimulation]{loadSimulation()}}, \code{\link[=getContainer]{getContainer()}} and \code{\link[=getAllContainersMatching]{getAllContainersMatching()}} to retrieve objects of type Container or Simulation
+\code{\link[=loadSimulation]{loadSimulation()}}, \code{\link[=getContainer]{getContainer()}} and
+\code{\link[=getAllContainersMatching]{getAllContainersMatching()}} to retrieve objects of type Container or
+Simulation
 }

--- a/man/getAllQuantityPathsIn.Rd
+++ b/man/getAllQuantityPathsIn.Rd
@@ -24,5 +24,7 @@ sim <- loadSimulation(simPath)
 quantityPaths <- getAllQuantityPathsIn(sim)
 }
 \seealso{
-\code{\link[=loadSimulation]{loadSimulation()}}, \code{\link[=getContainer]{getContainer()}} and \code{\link[=getAllContainersMatching]{getAllContainersMatching()}} to retrieve objects of type Container or Simulation
+\code{\link[=loadSimulation]{loadSimulation()}}, \code{\link[=getContainer]{getContainer()}} and
+\code{\link[=getAllContainersMatching]{getAllContainersMatching()}} to retrieve objects of type Container or
+Simulation
 }

--- a/man/getQuantity.Rd
+++ b/man/getQuantity.Rd
@@ -11,8 +11,8 @@ getQuantity(path, container, stopIfNotFound = TRUE)
 
 \item{container}{A Container or Simulation used to find the parameters}
 
-\item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no quantity exists for the given path,
-an error is thrown. If \code{FALSE}, \code{NULL} is returned.}
+\item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no quantity exists for
+the given path, an error is thrown. If \code{FALSE}, \code{NULL} is returned.}
 }
 \value{
 The \code{Quantity} with the given path. If the quantity for the path
@@ -29,5 +29,7 @@ sim <- loadSimulation(simPath)
 quantity <- getQuantity("Organism|Liver|Volume", sim)
 }
 \seealso{
-\code{\link[=loadSimulation]{loadSimulation()}}, \code{\link[=getContainer]{getContainer()}} and \code{\link[=getAllContainersMatching]{getAllContainersMatching()}} to retrieve objects of type Container or Simulation
+\code{\link[=loadSimulation]{loadSimulation()}}, \code{\link[=getContainer]{getContainer()}} and
+\code{\link[=getAllContainersMatching]{getAllContainersMatching()}} to retrieve objects of type Container or
+Simulation
 }

--- a/man/setMoleculeInitialValues.Rd
+++ b/man/setMoleculeInitialValues.Rd
@@ -13,8 +13,9 @@ setMoleculeInitialValues(molecules, values, units = NULL)
 of numeric values, if the start value of more than one molecule should be changed. Must have the same
 length as \code{molecules}}
 
-\item{units}{A string or a list of strings defining the units of the \code{values}. If \code{NULL} (default), values
-are assumed to be in base units. If not \code{NULL}, must have the same length as \code{quantities}.}
+\item{units}{A string or a list of strings defining the units of the
+\code{values}. If \code{NULL} (default), values are assumed to be in base units. If
+not \code{NULL}, must have the same length as \code{quantities}.}
 }
 \description{
 Set molecule start values

--- a/man/setMoleculeValuesByPath.Rd
+++ b/man/setMoleculeValuesByPath.Rd
@@ -19,13 +19,16 @@ setMoleculeValuesByPath(
 of numeric values, if the start value of more than one molecule should be changed. Must have the same
 length as \code{moleculePaths}}
 
-\item{simulation}{Simulation uses to retrieve quantity instances from given paths.}
+\item{simulation}{Simulation uses to retrieve quantity instances from given
+paths.}
 
-\item{units}{A string or a list of strings defining the units of the \code{values}. If \code{NULL} (default), values
-are assumed to be in base units. If not \code{NULL}, must have the same length as \code{quantityPaths}.}
+\item{units}{A string or a list of strings defining the units of the
+\code{values}. If \code{NULL} (default), values are assumed to be in base units. If
+not \code{NULL}, must have the same length as \code{quantityPaths}.}
 
-\item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no quantity exists for the given path,
-an error is thrown. If \code{FALSE}, a warning is shown to the user}
+\item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no quantity exists for
+the given path, an error is thrown. If \code{FALSE}, a warning is shown to the
+user.}
 }
 \description{
 Set molecule start values in the simulation by path

--- a/man/setParameterValues.Rd
+++ b/man/setParameterValues.Rd
@@ -13,8 +13,9 @@ setParameterValues(parameters, values, units = NULL)
 of numeric values, if the value of more than one parameter should be changed. Must have the same
 length as 'parameters'. Alternatively, the value can be a unique number. In that case, the same value will be set in all parameters}
 
-\item{units}{A string or a list of strings defining the units of the \code{values}. If \code{NULL} (default), values
-are assumed to be in base units. If not \code{NULL}, must have the same length as \code{quantities}.}
+\item{units}{A string or a list of strings defining the units of the
+\code{values}. If \code{NULL} (default), values are assumed to be in base units. If
+not \code{NULL}, must have the same length as \code{quantities}.}
 }
 \description{
 Set values of parameters

--- a/man/setParameterValuesByPath.Rd
+++ b/man/setParameterValuesByPath.Rd
@@ -21,8 +21,9 @@ length as 'parameterPaths'}
 
 \item{simulation}{Simulation uses to retrieve parameter instances from given paths.}
 
-\item{units}{A string or a list of strings defining the units of the \code{values}. If \code{NULL} (default), values
-are assumed to be in base units. If not \code{NULL}, must have the same length as \code{quantityPaths}.}
+\item{units}{A string or a list of strings defining the units of the
+\code{values}. If \code{NULL} (default), values are assumed to be in base units. If
+not \code{NULL}, must have the same length as \code{quantityPaths}.}
 
 \item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no parameter exists for the given path,
 an error is thrown. If \code{FALSE}, a warning is shown to the user}

--- a/man/setQuantityValues.Rd
+++ b/man/setQuantityValues.Rd
@@ -9,12 +9,15 @@ setQuantityValues(quantities, values, units = NULL)
 \arguments{
 \item{quantities}{A single or a list of \code{Quantity}}
 
-\item{values}{A numeric value that should be assigned to the quantity or a vector
-of numeric values, if the value of more than one quantity should be changed. Must have the same
-length as 'quantities'. Alternatively, the value can be a unique number. In that case, the same value will be set in all parameters}
+\item{values}{A numeric value that should be assigned to the quantity or a
+vector of numeric values, if the value of more than one quantity should be
+changed. Must have the same length as 'quantities'. Alternatively, the
+value can be a unique number. In that case, the same value will be set in
+all parameters}
 
-\item{units}{A string or a list of strings defining the units of the \code{values}. If \code{NULL} (default), values
-are assumed to be in base units. If not \code{NULL}, must have the same length as \code{quantities}.}
+\item{units}{A string or a list of strings defining the units of the
+\code{values}. If \code{NULL} (default), values are assumed to be in base units. If
+not \code{NULL}, must have the same length as \code{quantities}.}
 }
 \description{
 Set values of quantity

--- a/man/setQuantityValuesByPath.Rd
+++ b/man/setQuantityValuesByPath.Rd
@@ -15,17 +15,20 @@ setQuantityValuesByPath(
 \arguments{
 \item{quantityPaths}{A single or a list of absolute quantity path}
 
-\item{values}{A numeric value that should be assigned to the quantities or a vector
-of numeric values, if the value of more than one quantity should be changed. Must have the same
-length as 'quantityPaths'}
+\item{values}{A numeric value that should be assigned to the quantities or a
+vector of numeric values, if the value of more than one quantity should be
+changed. Must have the same length as 'quantityPaths'.}
 
-\item{simulation}{Simulation uses to retrieve quantity instances from given paths.}
+\item{simulation}{Simulation uses to retrieve quantity instances from given
+paths.}
 
-\item{units}{A string or a list of strings defining the units of the \code{values}. If \code{NULL} (default), values
-are assumed to be in base units. If not \code{NULL}, must have the same length as \code{quantityPaths}.}
+\item{units}{A string or a list of strings defining the units of the
+\code{values}. If \code{NULL} (default), values are assumed to be in base units. If
+not \code{NULL}, must have the same length as \code{quantityPaths}.}
 
-\item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no quantity exists for the given path,
-an error is thrown. If \code{FALSE}, a warning is shown to the user}
+\item{stopIfNotFound}{Boolean. If \code{TRUE} (default) and no quantity exists for
+the given path, an error is thrown. If \code{FALSE}, a warning is shown to the
+user.}
 }
 \description{
 Set the values of parameters in the simulation by path


### PR DESCRIPTION
#682 moved `finalize` from public to private methods, but their Rd documentation was still there, which is unnecessary since these are private methods.

This PR removes that documentation.

Additional, formatting changes to make code at a few locations a bit more tidy and docs to 80-character width.