### PR TITLE
fixes #698 Add artifacts without version number to enable usage as permalink

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,10 +78,10 @@ artifacts:
   - path: '*.Rcheck\**\*.Rout'
     name: Logs
 
-  - path: "ospsuite_*_ubuntu18.tar.gz"
+  - path: "ospsuite_*ubuntu18.tar.gz"
     name: Ubuntu18
 
-  - path: "ospsuite_*_centOS7.tar.gz"
+  - path: "ospsuite_*centOS7.tar.gz"
     name: CentOS7
 
   - path: '\*_*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ test_script:
 after_test:
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, ubuntu18]"
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, centOS7]"
-  - ps: copy ospsuite_*.zip ospsuite.zip
+  - ps: copy ospsuite_*.zip ospsuite_windows.zip
   - ps: copy ospsuite_*ubuntu18.tar.gz ospsuite_ubuntu18.tar.gz
   - ps: copy ospsuite_*centOS7.tar.gz ospsuite_centOS7.tar.gz
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,9 @@ test_script:
 after_test:
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, ubuntu18]"
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, centOS7]"
+  - ps: copy ospsuite_*.zip ospsuite.zip
+  - ps: copy ospsuite_*ubuntu18.tar.gz ospsuite_ubuntu18.tar.gz
+  - ps: copy ospsuite_*centOS7.tar.gz ospsuite_centOS7.tar.gz
 
 on_failure:
   - 7z a failure.zip *.Rcheck\*


### PR DESCRIPTION
Same as for tlf: adding artifacts without version (additionally to those with version) in order to enable using them via permalinks in the reporting engine builds etc.
![grafik](https://user-images.githubusercontent.com/25061876/145988453-27e1fa9c-898e-427f-ab21-aec7e8b06596.png)
