### PR TITLE
remove unnecessary namespace

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -90,7 +90,7 @@ Cache <- R6::R6Class(
       if (is.null(self$type)) {
         return()
       }
-      if (ospsuite.utils::isOfType(object, self$type)) {
+      if (isOfType(object, self$type)) {
         return()
       }
       # Name of the variable in the calling function

--- a/R/create-individual.R
+++ b/R/create-individual.R
@@ -14,7 +14,7 @@
 #'
 #' @export
 createIndividual <- function(individualCharacteristics) {
-  ospsuite.utils::validateIsOfType(individualCharacteristics, IndividualCharacteristics)
+  validateIsOfType(individualCharacteristics, IndividualCharacteristics)
 
   individualFactory <- rClr::clrCallStatic("PKSim.R.Api", "GetIndividualFactory")
   createIndividualResults <- rClr::clrCall(individualFactory, "CreateIndividual", individualCharacteristics$ref)
@@ -37,7 +37,7 @@ createIndividual <- function(individualCharacteristics) {
 #'
 #' @export
 createDistributions <- function(individualCharacteristics) {
-  ospsuite.utils::validateIsOfType(individualCharacteristics, IndividualCharacteristics)
+  validateIsOfType(individualCharacteristics, IndividualCharacteristics)
 
   individualFactory <- rClr::clrCallStatic("PKSim.R.Api", "GetIndividualFactory")
   distributedParameters <- rClr::clrCall(individualFactory, "DistributionsFor", individualCharacteristics$ref)
@@ -94,19 +94,19 @@ createIndividualCharacteristics <- function(species,
   # or should be initialized automatically
   initPKSim()
 
-  ospsuite.utils::validateIsString(species)
-  ospsuite.utils::validateIsString(population, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(gender, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(weight, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(weightUnit)
-  ospsuite.utils::validateIsNumeric(height, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(heightUnit)
-  ospsuite.utils::validateIsNumeric(age, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(ageUnit)
-  ospsuite.utils::validateIsNumeric(gestationalAge)
-  ospsuite.utils::validateIsString(gestationalAgeUnit)
-  ospsuite.utils::validateIsOfType(moleculeOntogenies, MoleculeOntogeny, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(seed, nullAllowed = TRUE)
+  validateIsString(species)
+  validateIsString(population, nullAllowed = TRUE)
+  validateIsString(gender, nullAllowed = TRUE)
+  validateIsNumeric(weight, nullAllowed = TRUE)
+  validateIsString(weightUnit)
+  validateIsNumeric(height, nullAllowed = TRUE)
+  validateIsString(heightUnit)
+  validateIsNumeric(age, nullAllowed = TRUE)
+  validateIsString(ageUnit)
+  validateIsNumeric(gestationalAge)
+  validateIsString(gestationalAgeUnit)
+  validateIsOfType(moleculeOntogenies, MoleculeOntogeny, nullAllowed = TRUE)
+  validateIsNumeric(seed, nullAllowed = TRUE)
 
   moleculeOntogenies <- c(moleculeOntogenies)
   individualCharacteristics <- IndividualCharacteristics$new()

--- a/R/create-population.R
+++ b/R/create-population.R
@@ -10,7 +10,7 @@
 #'
 #' @export
 createPopulation <- function(populationCharacteristics) {
-  ospsuite.utils::validateIsOfType(populationCharacteristics, PopulationCharacteristics)
+  validateIsOfType(populationCharacteristics, PopulationCharacteristics)
 
   populationFactory <- rClr::clrCallStatic("PKSim.R.Api", "GetPopulationFactory")
   results <- rClr::clrCall(populationFactory, "CreatePopulation", populationCharacteristics$ref)
@@ -108,33 +108,33 @@ createPopulationCharacteristics <- function(species,
   # or should be initialized automatically
   initPKSim()
 
-  ospsuite.utils::validateIsString(species)
-  ospsuite.utils::validateIsString(population, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(numberOfIndividuals)
-  ospsuite.utils::validateIsNumeric(proportionOfFemales)
+  validateIsString(species)
+  validateIsString(population, nullAllowed = TRUE)
+  validateIsNumeric(numberOfIndividuals)
+  validateIsNumeric(proportionOfFemales)
 
-  ospsuite.utils::validateIsNumeric(weightMin, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(weightMax, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(weightUnit)
+  validateIsNumeric(weightMin, nullAllowed = TRUE)
+  validateIsNumeric(weightMax, nullAllowed = TRUE)
+  validateIsString(weightUnit)
 
-  ospsuite.utils::validateIsNumeric(heightMin, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(heightMax, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(heightUnit)
+  validateIsNumeric(heightMin, nullAllowed = TRUE)
+  validateIsNumeric(heightMax, nullAllowed = TRUE)
+  validateIsString(heightUnit)
 
-  ospsuite.utils::validateIsNumeric(ageMin, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(ageMax, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(ageUnit)
+  validateIsNumeric(ageMin, nullAllowed = TRUE)
+  validateIsNumeric(ageMax, nullAllowed = TRUE)
+  validateIsString(ageUnit)
 
-  ospsuite.utils::validateIsNumeric(BMIMin, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(BMIMax, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(BMIUnit)
+  validateIsNumeric(BMIMin, nullAllowed = TRUE)
+  validateIsNumeric(BMIMax, nullAllowed = TRUE)
+  validateIsString(BMIUnit)
 
-  ospsuite.utils::validateIsInteger(gestationalAgeMin, nullAllowed = TRUE)
-  ospsuite.utils::validateIsInteger(gestationalAgeMax, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(gestationalAgeUnit)
+  validateIsInteger(gestationalAgeMin, nullAllowed = TRUE)
+  validateIsInteger(gestationalAgeMax, nullAllowed = TRUE)
+  validateIsString(gestationalAgeUnit)
 
-  ospsuite.utils::validateIsOfType(moleculeOntogenies, MoleculeOntogeny, nullAllowed = TRUE)
-  ospsuite.utils::validateIsInteger(seed, nullAllowed = TRUE)
+  validateIsOfType(moleculeOntogenies, MoleculeOntogeny, nullAllowed = TRUE)
+  validateIsInteger(seed, nullAllowed = TRUE)
 
   moleculeOntogenies <- c(moleculeOntogenies)
   populationCharacteristics <- PopulationCharacteristics$new()

--- a/R/data-column.R
+++ b/R/data-column.R
@@ -62,7 +62,7 @@ DataColumn <- R6::R6Class(
         return(rClr::clrGet(dataInfo, "MolWeight"))
       }
 
-      ospsuite.utils::validateIsNumeric(value)
+      validateIsNumeric(value)
       rClr::clrSet(dataInfo, "MolWeight", value)
     },
     #' @field LLOQ Lower Limit Of Quantification.
@@ -73,7 +73,7 @@ DataColumn <- R6::R6Class(
         return(rClr::clrGet(dataInfo, "LLOQAsDouble"))
       }
 
-      ospsuite.utils::validateIsNumeric(value)
+      validateIsNumeric(value)
       rClr::clrSet(dataInfo, "LLOQAsDouble", value)
     }
   ),

--- a/R/data-importer-configuration.R
+++ b/R/data-importer-configuration.R
@@ -14,7 +14,7 @@ DataImporterConfiguration <- R6::R6Class(
       if (missing(value)) {
         return(rClr::clrGet(column, "ColumnName"))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       rClr::clrSet(column, "ColumnName", enc2utf8(value))
     },
 
@@ -31,7 +31,7 @@ DataImporterConfiguration <- R6::R6Class(
         }
         return(rClr::clrGet(unit, "SelectedUnit"))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       private$.setColumnUnit(column = column, value = value)
     },
 
@@ -43,7 +43,7 @@ DataImporterConfiguration <- R6::R6Class(
       if (missing(value)) {
         return(private$.isUnitFromColumn(column))
       }
-      ospsuite.utils::validateIsLogical(value)
+      validateIsLogical(value)
       rClr::clrCall(private$.dataImporterTask, "SetIsUnitFromColumn", column, value)
     },
 
@@ -53,7 +53,7 @@ DataImporterConfiguration <- R6::R6Class(
       if (missing(value)) {
         return(rClr::clrGet(column, "ColumnName"))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       rClr::clrSet(column, "ColumnName", enc2utf8(value))
     },
 
@@ -72,7 +72,7 @@ DataImporterConfiguration <- R6::R6Class(
         dimension <- rClr::clrGet(mappedColumn, "Dimension")
         return(rClr::clrGet(dimension, "DisplayName"))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       # Fixed unit or from column?
       if (private$.isUnitFromColumn(column)) {
         # do nothing as it should be NULL
@@ -106,7 +106,7 @@ DataImporterConfiguration <- R6::R6Class(
         }
         return(rClr::clrGet(unit, "SelectedUnit"))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       private$.setColumnUnit(column = column, value = value)
     },
 
@@ -118,7 +118,7 @@ DataImporterConfiguration <- R6::R6Class(
       if (missing(value)) {
         return(private$.isUnitFromColumn(column))
       }
-      ospsuite.utils::validateIsLogical(value)
+      validateIsLogical(value)
       rClr::clrCall(private$.dataImporterTask, "SetIsUnitFromColumn", column, value)
       # Also change isUnitFromColumn for error column
       if (!is.null(private$.errorColumn)) {
@@ -139,7 +139,7 @@ DataImporterConfiguration <- R6::R6Class(
         rClr::clrCall(private$.dataImporterTask, "RemoveError", self$ref)
         private$.errorColumn <- NULL
       } else {
-        ospsuite.utils::validateIsString(value)
+        validateIsString(value)
         # Create an error column if none is present in the configuration
         if (is.null(column)) {
           private$.addErrorColumn()
@@ -169,7 +169,7 @@ DataImporterConfiguration <- R6::R6Class(
         }
         return(rClr::clrGet(unit, "SelectedUnit"))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       private$.setColumnUnit(column = column, value = value)
     },
 
@@ -217,7 +217,7 @@ DataImporterConfiguration <- R6::R6Class(
         rClr::clrCall(self$ref, "ClearLoadedSheets")
         return(invisible(self))
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       rClr::clrCall(private$.dataImporterTask, "SetAllLoadedSheet", self$ref, value)
     },
     #' @field namingPattern Regular expression used for naming of loaded data sets.
@@ -234,7 +234,7 @@ DataImporterConfiguration <- R6::R6Class(
         }
         return(pattern)
       }
-      ospsuite.utils::validateIsString(value)
+      validateIsString(value)
       rClr::clrSet(self$ref, "NamingConventions", enc2utf8(value))
     }
   ),
@@ -252,7 +252,7 @@ DataImporterConfiguration <- R6::R6Class(
       if (is.null(configurationFilePath)) {
         ref <- rClr::clrCall(importerTask, "CreateConfiguration")
       } else {
-        ospsuite.utils::validateIsString(configurationFilePath)
+        validateIsString(configurationFilePath)
         ref <- rClr::clrCall(importerTask, "GetConfiguration", configurationFilePath)
       }
       super$initialize(ref)
@@ -268,7 +268,7 @@ DataImporterConfiguration <- R6::R6Class(
     #' @param filePath Path (incl. file name) to the location where the configuration
     #' will be exported to.
     saveConfiguration = function(filePath) {
-      ospsuite.utils::validateIsString(filePath)
+      validateIsString(filePath)
       filePath <- expandPath(filePath)
 
       rClr::clrCall(private$.dataImporterTask, "SaveConfiguration", self$ref, filePath)
@@ -279,7 +279,7 @@ DataImporterConfiguration <- R6::R6Class(
     #' Add a column for grouping the data sets
     #' @param column Name of the column
     addGroupingColumn = function(column) {
-      ospsuite.utils::validateIsString(column)
+      validateIsString(column)
       rClr::clrCall(private$.dataImporterTask, "AddGroupingColumn", self$ref, enc2utf8(column))
       invisible(self)
     },
@@ -288,7 +288,7 @@ DataImporterConfiguration <- R6::R6Class(
     #' Remove a column for grouping the data sets
     #' @param column Name of the column
     removeGroupingColumn = function(column) {
-      ospsuite.utils::validateIsString(column)
+      validateIsString(column)
       rClr::clrCall(private$.dataImporterTask, "RemoveGroupingColumn", self$ref, enc2utf8(column))
       invisible(self)
     },
@@ -354,7 +354,7 @@ DataImporterConfiguration <- R6::R6Class(
 #' to the values supported in the importer configuration
 #'
 #' @keywords internal
-.ImporterErrorTypeToDataSetErrorType <- ospsuite.utils::enum(c(
+.ImporterErrorTypeToDataSetErrorType <- enum(c(
   "Arithmetic Standard Deviation" = "ArithmeticStdDev",
   "Geometric Standard Deviation" = "GeometricStdDev"
 ))

--- a/R/data-repository.R
+++ b/R/data-repository.R
@@ -62,7 +62,7 @@ DataRepository <- R6::R6Class(
     #' Adds a column to the data repository
     #' @param column Column to add
     addColumn = function(column) {
-      ospsuite.utils::validateIsOfType(column, DataColumn)
+      validateIsOfType(column, DataColumn)
       rClr::clrCall(self$ref, "Add", column$ref)
       # we need to reset the cache when adding a new column
       private$.columns <- NULL
@@ -91,8 +91,8 @@ DataRepository <- R6::R6Class(
       if (length(name) != 1) {
         stop(messages$errorMultipleMetaDataEntries())
       }
-      ospsuite.utils::validateIsString(name)
-      ospsuite.utils::validateIsString(value)
+      validateIsString(name)
+      validateIsString(value)
       dataRepositoryTask <- getNetTask("DataRepositoryTask")
       rClr::clrCall(dataRepositoryTask, "AddMetaData", self$ref, name, value)
       # we need to reset the cache when adding a new meta data
@@ -106,7 +106,7 @@ DataRepository <- R6::R6Class(
       if (length(name) != 1) {
         stop(messages$errorMultipleMetaDataEntries())
       }
-      ospsuite.utils::validateIsString(name)
+      validateIsString(name)
       dataRepositoryTask <- getNetTask("DataRepositoryTask")
       rClr::clrCall(dataRepositoryTask, "RemoveMetaData", self$ref, name)
       # we need to reset the cache when adding a new meta data

--- a/R/data-set.R
+++ b/R/data-set.R
@@ -1,7 +1,7 @@
 #' Supported types of the error
 #' 
 #' @export
-DataErrorType <- ospsuite.utils::enum(c(
+DataErrorType <- enum(c(
   "ArithmeticStdDev",
   "GeometricStdDev"
 ))
@@ -235,12 +235,12 @@ DataSet <- R6::R6Class(
     #' @param yErrorValues Optional error values associated with yValues
 
     setValues = function(xValues, yValues, yErrorValues = NULL) {
-      ospsuite.utils::validateIsNumeric(xValues)
-      ospsuite.utils::validateIsNumeric(yValues)
-      ospsuite.utils::validateIsNumeric(yErrorValues, nullAllowed = TRUE)
-      ospsuite.utils::validateIsSameLength(xValues, yValues)
+      validateIsNumeric(xValues)
+      validateIsNumeric(yValues)
+      validateIsNumeric(yErrorValues, nullAllowed = TRUE)
+      validateIsSameLength(xValues, yValues)
       if (!is.null(yErrorValues)) {
-        ospsuite.utils::validateIsSameLength(xValues, yErrorValues)
+        validateIsSameLength(xValues, yErrorValues)
       }
 
       private$.setColumnValues(column = private$.xColumn, xValues)

--- a/R/dot-net-wrapper.R
+++ b/R/dot-net-wrapper.R
@@ -39,8 +39,8 @@ DotNetWrapper <- R6::R6Class(
         if (is.null(value) && !shouldSetNull) {
           return()
         }
-        if (ospsuite.utils::isOfType(type = "character", object = value)) {
-          # ospsuite.utils::isOfType returns TRUE for empty `object` and enc2utf8(value) fails
+        if (isOfType(type = "character", object = value)) {
+          # isOfType returns TRUE for empty `object` and enc2utf8(value) fails
           if (length(value) > 0) {
             value <- enc2utf8(value)
           }

--- a/R/error-checks.R
+++ b/R/error-checks.R
@@ -1,6 +1,6 @@
 validateHasUnit <- function(quantity, unit) {
-  ospsuite.utils::validateIsOfType(quantity, Quantity)
-  ospsuite.utils::validateIsString(unit)
+  validateIsOfType(quantity, Quantity)
+  validateIsString(unit)
   if (quantity$hasUnit(unit)) {
     return()
   }

--- a/R/individual-characteristics.R
+++ b/R/individual-characteristics.R
@@ -98,7 +98,7 @@ IndividualCharacteristics <- R6::R6Class(
     #' Add a molecule ontogeny `MoleculeOntogeny` to the individual characteristics
     #' @param moleculeOntogeny Molecule ontogeny to add
     addMoleculeOntogeny = function(moleculeOntogeny) {
-      ospsuite.utils::validateIsOfType(moleculeOntogeny, MoleculeOntogeny)
+      validateIsOfType(moleculeOntogeny, MoleculeOntogeny)
       private$.moleculeOntogenies <- c(private$.moleculeOntogenies, moleculeOntogeny)
       netMoleculeOntogeny <- rClr::clrNew("PKSim.R.Domain.MoleculeOntogeny")
       rClr::clrSet(netMoleculeOntogeny, "Molecule", moleculeOntogeny$molecule)

--- a/R/molecule-ontogeny.R
+++ b/R/molecule-ontogeny.R
@@ -21,7 +21,7 @@ MoleculeOntogeny <- R6::R6Class(
     #' @param ontogeny ontogeny to use for the Molecule (one of StandardOntogeny)
     #' @return A new `MoleculeOntogeny` object.
     initialize = function(molecule, ontogeny) {
-      ospsuite.utils::validateIsString(molecule)
+      validateIsString(molecule)
       validateEnumValue(ontogeny, StandardOntogeny)
       self$molecule <- molecule
       self$ontogeny <- ontogeny

--- a/R/output-schema.R
+++ b/R/output-schema.R
@@ -37,7 +37,7 @@ OutputSchema <- R6::R6Class(
     #' Adds an interval to the schema
     #' @param interval Interval to add
     addInterval = function(interval) {
-      ospsuite.utils::validateIsOfType(interval, Interval)
+      validateIsOfType(interval, Interval)
       rClr::clrCall(self$ref, "AddInterval", interval$ref)
       invisible(self)
     },
@@ -45,7 +45,7 @@ OutputSchema <- R6::R6Class(
     #' Removes the interval from the schema
     #' @param interval Interval to remove
     removeInterval = function(interval) {
-      ospsuite.utils::validateIsOfType(interval, Interval)
+      validateIsOfType(interval, Interval)
       rClr::clrCall(self$ref, "RemoveInterval", interval$ref)
       invisible(self)
     },
@@ -56,7 +56,7 @@ OutputSchema <- R6::R6Class(
     #' @param timePoints Time points to add to the schema
     addTimePoints = function(timePoints) {
       timePoints <- c(timePoints)
-      ospsuite.utils::validateIsNumeric(timePoints)
+      validateIsNumeric(timePoints)
       if (length(timePoints) > 1) {
         rClr::clrCall(self$ref, "AddTimePoints", timePoints)
       } else {

--- a/R/output-selections.R
+++ b/R/output-selections.R
@@ -26,14 +26,14 @@ OutputSelections <- R6::R6Class(
     #' Adds a quantity as selected
     #' @param quantity Quantity to add to the selection
     addQuantity = function(quantity) {
-      ospsuite.utils::validateIsOfType(quantity, Quantity)
+      validateIsOfType(quantity, Quantity)
       rClr::clrCall(self$ref, "AddQuantity", quantity$ref)
     },
     #' @description
     #' Removes a quantity from the selection
     #' @param quantity Quantity to remove from the selection
     removeQuantity = function(quantity) {
-      ospsuite.utils::validateIsOfType(quantity, Quantity)
+      validateIsOfType(quantity, Quantity)
       rClr::clrCall(self$ref, "RemoveQuantity", quantity$ref)
     },
     #' @description

--- a/R/parameter-range.R
+++ b/R/parameter-range.R
@@ -30,9 +30,9 @@ ParameterRange <- R6::R6Class(
     #' @param unit Optional unit of the specified min and max
     #' @return A new `ParameterRange` object.
     initialize = function(ref = NULL, min = NULL, max = NULL, unit = NULL) {
-      ospsuite.utils::validateIsNumeric(min, nullAllowed = TRUE)
-      ospsuite.utils::validateIsNumeric(max, nullAllowed = TRUE)
-      ospsuite.utils::validateIsString(unit, nullAllowed = TRUE)
+      validateIsNumeric(min, nullAllowed = TRUE)
+      validateIsNumeric(max, nullAllowed = TRUE)
+      validateIsString(unit, nullAllowed = TRUE)
       ref <- ref %||% rClr::clrNew("PKSim.Core.Snapshots.ParameterRange")
       super$initialize(ref)
       # Because of weird issue with nullable value in rClr

--- a/R/parameter.R
+++ b/R/parameter.R
@@ -24,7 +24,7 @@ Parameter <- R6::R6Class(
       if (missing(value)) {
         return(hasRHSFormula)
       }
-      ospsuite.utils::validateIsLogical(value)
+      validateIsLogical(value)
 
       # Set to TRUE AND we have a rhs, nothing to do
       if (value && hasRHSFormula) {

--- a/R/path-explorer.R
+++ b/R/path-explorer.R
@@ -48,10 +48,10 @@ nextStep <- function(listSoFar, originalString, arrayToGo) {
 #' liver_volume_path <- tree$Organism$Liver$Volume$path
 #' @export
 getSimulationTree <- function(simulationOrFilePath) {
-  ospsuite.utils::validateIsOfType(simulationOrFilePath, c(Simulation, "character"))
+  validateIsOfType(simulationOrFilePath, c(Simulation, "character"))
 
   simulation <- simulationOrFilePath
-  if (ospsuite.utils::isOfType(simulationOrFilePath, "character")) {
+  if (isOfType(simulationOrFilePath, "character")) {
     simulation <- loadSimulation(simulationOrFilePath)
   }
 

--- a/R/pk-parameter.R
+++ b/R/pk-parameter.R
@@ -2,7 +2,7 @@
 #' This is only used to defined how a user defined PK Parameter should be calculated
 #' 
 #' @export
-StandardPKParameter <- ospsuite.utils::enum(c(
+StandardPKParameter <- enum(c(
   Unknown = 0,
   C_max = 1,
   C_max_norm = 2,

--- a/R/pk-sim.R
+++ b/R/pk-sim.R
@@ -3,7 +3,7 @@
 #'
 #' 
 #' @export
-Species <- ospsuite.utils::enum(c(
+Species <- enum(c(
   "Beagle",
   "Dog",
   "Human",
@@ -18,7 +18,7 @@ Species <- ospsuite.utils::enum(c(
 #'
 #' 
 #' @export
-HumanPopulation <- ospsuite.utils::enum(c(
+HumanPopulation <- enum(c(
   "Asian_Tanaka_1996",
   "BlackAmerican_NHANES_1997",
   "European_ICRP_2002",
@@ -33,7 +33,7 @@ HumanPopulation <- ospsuite.utils::enum(c(
 #'
 #' 
 #' @export
-Gender <- ospsuite.utils::enum(c(
+Gender <- enum(c(
   Female = "FEMALE",
   Male = "MALE",
   Unknown = "UNKNOWN"
@@ -43,7 +43,7 @@ Gender <- ospsuite.utils::enum(c(
 #'
 #' 
 #' @export
-StandardOntogeny <- ospsuite.utils::enum(c(
+StandardOntogeny <- enum(c(
   "CYP1A2",
   "CYP2C18",
   "CYP2C19",

--- a/R/population-characteristics.R
+++ b/R/population-characteristics.R
@@ -109,7 +109,7 @@ PopulationCharacteristics <- R6::R6Class(
     #' Add a molecule ontogeny `MoleculeOntogeny` to the individual characteristics
     #' @param moleculeOntogeny Molecule ontogeny to add
     addMoleculeOntogeny = function(moleculeOntogeny) {
-      ospsuite.utils::validateIsOfType(moleculeOntogeny, MoleculeOntogeny)
+      validateIsOfType(moleculeOntogeny, MoleculeOntogeny)
       private$.moleculeOntogenies <- c(private$.moleculeOntogenies, moleculeOntogeny)
       netMoleculeOntogeny <- rClr::clrNew("PKSim.R.Domain.MoleculeOntogeny")
       rClr::clrSet(netMoleculeOntogeny, "Molecule", moleculeOntogeny$molecule)

--- a/R/population.R
+++ b/R/population.R
@@ -39,7 +39,7 @@ Population <- R6::R6Class(
     #' @param values double vector containing the value to set for the `parameterOrPath`
     setParameterValues = function(parameterOrPath, values) {
       parameterPath <- private$getPathFrom(parameterOrPath)
-      ospsuite.utils::validateIsNumeric(values)
+      validateIsNumeric(values)
       rClr::clrCall(self$ref, "SetValues", parameterPath, values)
       invisible(self)
     },
@@ -86,8 +86,8 @@ Population <- R6::R6Class(
   ),
   private = list(
     getPathFrom = function(parameterOrPath) {
-      ospsuite.utils::validateIsOfType(parameterOrPath, c("character", Parameter))
-      if (ospsuite.utils::isOfType(parameterOrPath, Parameter)) {
+      validateIsOfType(parameterOrPath, c("character", Parameter))
+      if (isOfType(parameterOrPath, Parameter)) {
         return(parameterOrPath$path)
       }
       parameterOrPath

--- a/R/quantity.R
+++ b/R/quantity.R
@@ -125,8 +125,8 @@ Quantity <- R6::R6Class(
     #' @param value Value to set. If unit is null, we assume that the value is in base unit
     #' @param unit Optional unit in which the value is given.
     setValue = function(value, unit = NULL) {
-      ospsuite.utils::validateIsNumeric(value)
-      ospsuite.utils::validateIsString(unit, nullAllowed = TRUE)
+      validateIsNumeric(value)
+      validateIsString(unit, nullAllowed = TRUE)
       if (!is.null(unit)) {
         unit <- encodeUnit(unit)
         validateHasUnit(self, unit)
@@ -139,7 +139,7 @@ Quantity <- R6::R6Class(
     #' For the list of supported units, use `allUnits`
     #' @param unit Unit to check
     hasUnit = function(unit) {
-      ospsuite.utils::validateIsString(unit)
+      validateIsString(unit)
       any(self$allUnits == unit)
     },
     #' @description

--- a/R/sensitivity-analysis-results.R
+++ b/R/sensitivity-analysis-results.R
@@ -36,7 +36,7 @@ SensitivityAnalysisResults <- R6::R6Class("SensitivityAnalysisResults",
     #' @param simulation Reference to the simulation object used to calculated the results
     #' @return A new `SensitivityAnalysisResults` object.
     initialize = function(ref, simulation) {
-      ospsuite.utils::validateIsOfType(simulation, Simulation)
+      validateIsOfType(simulation, Simulation)
       private$.simulation <- simulation
       super$initialize(ref)
     },
@@ -49,9 +49,9 @@ SensitivityAnalysisResults <- R6::R6Class("SensitivityAnalysisResults",
     allPKParameterSensitivitiesFor = function(pkParameterName,
                                               outputPath,
                                               totalSensitivityThreshold = ospsuiteEnv$sensitivityAnalysisConfig$totalSensitivityThreshold) {
-      ospsuite.utils::validateIsString(pkParameterName)
-      ospsuite.utils::validateIsString(outputPath)
-      ospsuite.utils::validateIsNumeric(totalSensitivityThreshold)
+      validateIsString(pkParameterName)
+      validateIsString(outputPath)
+      validateIsNumeric(totalSensitivityThreshold)
       pkParameterSentitivities <- rClr::clrCall(self$ref, "AllPKParameterSensitivitiesFor", pkParameterName, outputPath, totalSensitivityThreshold)
       toObjectType(pkParameterSentitivities, PKParameterSensitivity)
     },

--- a/R/sensitivity-analysis.R
+++ b/R/sensitivity-analysis.R
@@ -36,8 +36,8 @@ SensitivityAnalysis <- R6::R6Class(
                           parameterPaths = NULL,
                           numberOfSteps = ospsuiteEnv$sensitivityAnalysisConfig$numberOfSteps,
                           variationRange = ospsuiteEnv$sensitivityAnalysisConfig$variationRange) {
-      ospsuite.utils::validateIsOfType(simulation, Simulation)
-      ospsuite.utils::validateIsString(parameterPaths, nullAllowed = TRUE)
+      validateIsOfType(simulation, Simulation)
+      validateIsString(parameterPaths, nullAllowed = TRUE)
       ref <- rClr::clrNew("OSPSuite.R.Domain.SensitivityAnalysis", simulation$ref)
       super$initialize(ref)
       private$.simulation <- simulation
@@ -52,7 +52,7 @@ SensitivityAnalysis <- R6::R6Class(
     #' If no parameters were specified during creating of a `SensitivityAnalysis` (all constant parameters are considered),
     #' calling `addParameterPaths` will make only the manually added parameters being varied.
     addParameterPaths = function(parameterPaths) {
-      ospsuite.utils::validateIsString(parameterPaths)
+      validateIsString(parameterPaths)
       parameterPaths <- c(parameterPaths)
       private$.parameterPaths <- c(private$.parameterPaths, parameterPaths)
       private$.addParameterPaths(parameterPaths)

--- a/R/simulation-batch.R
+++ b/R/simulation-batch.R
@@ -24,7 +24,7 @@ SimulationBatch <- R6::R6Class(
     #' @param simulation Simulation used in the batch run
     #' @return A new `SimulationBatch` object.
     initialize = function(ref, simulation) {
-      ospsuite.utils::validateIsOfType(simulation, Simulation)
+      validateIsOfType(simulation, Simulation)
       super$initialize(ref)
       private$.simulation <- simulation
     },
@@ -61,8 +61,8 @@ SimulationBatch <- R6::R6Class(
     #' res <- runSimulationBatches(simulationBatches = list(simulationBatch1, simulationBatch2))
     #' }
     addRunValues = function(parameterValues = NULL, initialValues = NULL) {
-      ospsuite.utils::validateIsNumeric(parameterValues, nullAllowed = TRUE)
-      ospsuite.utils::validateIsNumeric(initialValues, nullAllowed = TRUE)
+      validateIsNumeric(parameterValues, nullAllowed = TRUE)
+      validateIsNumeric(initialValues, nullAllowed = TRUE)
       # Only one values set is allowed - no lists of values
       if (is.list(parameterValues) || is.list(initialValues)) {
         stop(messages$errorOnlyOneValuesSetAllowed("parameterValues, initialValues"))

--- a/R/simulation-pk-analyses.R
+++ b/R/simulation-pk-analyses.R
@@ -20,7 +20,7 @@ SimulationPKAnalyses <- R6::R6Class(
     #' @param simulation Simulation for which the pkParameters were calculated
     #' @return A new `SimulationPKAnalyses` object.
     initialize = function(ref, simulation) {
-      ospsuite.utils::validateIsOfType(simulation, Simulation)
+      validateIsOfType(simulation, Simulation)
       private$.simulation <- simulation
       super$initialize(ref)
     },
@@ -28,7 +28,7 @@ SimulationPKAnalyses <- R6::R6Class(
     #' Returns all QuantityPKParameter defined for a given path
     #' @param quantityPath Path for which pkParameters should be retrieved
     allPKParametersFor = function(quantityPath) {
-      ospsuite.utils::validateIsString(quantityPath)
+      validateIsString(quantityPath)
       private$toPKParameter(rClr::clrCall(self$ref, "AllPKParametersFor", quantityPath))
     },
     #' @description
@@ -37,8 +37,8 @@ SimulationPKAnalyses <- R6::R6Class(
     #'   should be retrieved
     #' @param pkParameter Name of the pkParameter to retrieve
     pKParameterFor = function(quantityPath, pkParameter) {
-      ospsuite.utils::validateIsString(quantityPath)
-      ospsuite.utils::validateIsString(pkParameter)
+      validateIsString(quantityPath)
+      validateIsString(pkParameter)
       private$toPKParameter(rClr::clrCall(self$ref, "PKParameterFor", quantityPath, pkParameter))
     },
 

--- a/R/simulation-results.R
+++ b/R/simulation-results.R
@@ -12,7 +12,7 @@ SimulationResults <- R6::R6Class(
     .simulation = NULL,
     .individualResultsCache = NULL,
     getResultsForIndividual = function(individualId) {
-      ospsuite.utils::validateIsNumeric(individualId)
+      validateIsNumeric(individualId)
       rClr::clrCall(self$ref, "ResultsFor", as.integer(individualId))
     },
     allIndividualResults = function(value) {
@@ -30,7 +30,7 @@ SimulationResults <- R6::R6Class(
     #' @param simulation Reference to the simulation object used to calculated the results
     #' @return A new `SimulationResults` object.
     initialize = function(ref, simulation) {
-      ospsuite.utils::validateIsOfType(simulation, Simulation)
+      validateIsOfType(simulation, Simulation)
       private$.simulation <- simulation
       private$.individualResultsCache <- Cache$new()
       super$initialize(ref)
@@ -39,7 +39,7 @@ SimulationResults <- R6::R6Class(
     #' Returns `TRUE` if results are available for the individual with id `individualId` otherwise `FALSE`
     #' @param individualId Id of the individual
     hasResultsForIndividual = function(individualId) {
-      ospsuite.utils::validateIsNumeric(individualId)
+      validateIsNumeric(individualId)
       rClr::clrCall(self$ref, "HasResultsFor", as.integer(individualId))
     },
     #' @description
@@ -49,7 +49,7 @@ SimulationResults <- R6::R6Class(
     #' @param stopIfNotFound If `TRUE` (default) an error is thrown if no values could be found for the `path`/
     #' If `FALSE`, a list of `NA` values is returned
     getValuesByPath = function(path, individualIds, stopIfNotFound = TRUE) {
-      ospsuite.utils::validateIsNumeric(individualIds)
+      validateIsNumeric(individualIds)
       individualIds <- c(individualIds)
       values <- rClr::clrCall(self$ref, "AllValuesFor", path, as.integer(individualIds))
 
@@ -64,7 +64,7 @@ SimulationResults <- R6::R6Class(
     #' Returns all available results for the individual with id `individualId`
     #' @param individualId Id for which the results should be returned
     resultsForIndividual = function(individualId) {
-      ospsuite.utils::validateIsNumeric(individualId)
+      validateIsNumeric(individualId)
       if (!private$.individualResultsCache$hasKey(individualId)) {
         individualResult <- private$getResultsForIndividual(individualId)
         private$.individualResultsCache$set(individualId, individualResult)

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -80,7 +80,7 @@ Simulation <- R6::R6Class(
     #' Returns the mol weight value (in core unit) associated to the quantity with given path or NA if not found
     #' @param quantityPath Path of quantity used to retrieve the molecular weight
     molWeightFor = function(quantityPath) {
-      ospsuite.utils::validateIsString(quantityPath)
+      validateIsString(quantityPath)
       mw <- rClr::clrCall(self$ref, "MolWeightFor", quantityPath)
       mw %||% NA_real_
     },
@@ -88,7 +88,7 @@ Simulation <- R6::R6Class(
     #' Returns the applications ordered by start time associated to the quantity with path `quantityPath` or an empty list if not found
     #' @param quantityPath Path of quantity used to retrieve the applications (e.g. applications resulting in this quantity being applied)
     allApplicationsFor = function(quantityPath) {
-      ospsuite.utils::validateIsString(quantityPath)
+      validateIsString(quantityPath)
       netApplicationParameters <- rClr::clrCallStatic(MODEL_CORE_SIMULATION_EXTENSIONS, "AllApplicationParametersOrderedByStartTimeForQuantityPath", self$ref, quantityPath)
       toObjectType(netApplicationParameters, Application)
     },

--- a/R/snapshot-parameter.R
+++ b/R/snapshot-parameter.R
@@ -25,8 +25,8 @@ SnapshotParameter <- R6::R6Class(
     #' @param unit Optional unit of the value specified.
     #' @return A new `SnapshotParameter` object.
     initialize = function(ref = NULL, value = NULL, unit = NULL) {
-      ospsuite.utils::validateIsNumeric(value, nullAllowed = TRUE)
-      ospsuite.utils::validateIsString(unit, nullAllowed = TRUE)
+      validateIsNumeric(value, nullAllowed = TRUE)
+      validateIsString(unit, nullAllowed = TRUE)
       ref <- ref %||% rClr::clrNew("PKSim.Core.Snapshots.Parameter")
       super$initialize(ref)
       # Because of weird issue with nullable value in rClr

--- a/R/standard-path.R
+++ b/R/standard-path.R
@@ -3,7 +3,7 @@
 #'
 #' 
 #' @export
-StandardContainer <- ospsuite.utils::enum(c(
+StandardContainer <- enum(c(
   Organism = "Organism",
   Applications = "Applications",
   Neighborhoods = "Neighborhoods",
@@ -15,7 +15,7 @@ StandardContainer <- ospsuite.utils::enum(c(
 #' 
 #' @include utilities-path.R
 #' @export
-StandardPath <- ospsuite.utils::enum(c(
+StandardPath <- enum(c(
   Age = toPathString(StandardContainer$Organism, "Age"),
   Height = toPathString(StandardContainer$Organism, "Height"),
   Weight = toPathString(StandardContainer$Organism, "Weight"),
@@ -30,7 +30,7 @@ StandardPath <- ospsuite.utils::enum(c(
 #'
 #' 
 #' @export
-MoleculeParameter <- ospsuite.utils::enum(c(
+MoleculeParameter <- enum(c(
   ReferenceConcentration = "Reference concentration",
   THalfLiver = "t1/2 (liver)",
   THalfIntestine = "t1/2 (intestine)",

--- a/R/table-formula.R
+++ b/R/table-formula.R
@@ -34,9 +34,9 @@ TableFormula <- R6::R6Class(
     addPoints = function(xValues, yValues) {
       xValues <- c(xValues)
       yValues <- c(yValues)
-      ospsuite.utils::validateIsNumeric(xValues)
-      ospsuite.utils::validateIsNumeric(yValues)
-      ospsuite.utils::validateIsSameLength(xValues, yValues)
+      validateIsNumeric(xValues)
+      validateIsNumeric(yValues)
+      validateIsSameLength(xValues, yValues)
       for (i in seq_along(xValues)) {
         rClr::clrCall(self$ref, "AddPoint", xValues[i], yValues[i])
       }

--- a/R/utilities-data-repository.R
+++ b/R/utilities-data-repository.R
@@ -4,7 +4,7 @@
 #' @param filePath Full path of pkml file containing the observed data to load
 #' @keywords internal
 .loadDataRepositoryFromPKML <- function(filePath) {
-  ospsuite.utils::validateIsString(filePath)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   dataRepositoryTask <- getNetTask("DataRepositoryTask")
   dataRepository <- rClr::clrCall(dataRepositoryTask, "LoadDataRepository", filePath)

--- a/R/utilities-data-set.R
+++ b/R/utilities-data-set.R
@@ -54,8 +54,8 @@ loadDataSetFromPKML <- function(filePath) {
 #' dataSet$saveToPKML(filePath = "../ObsData.pkml")
 #' }
 saveDataSetToPKML <- function(dataSet, filePath) {
-  ospsuite.utils::validateIsString(filePath)
-  ospsuite.utils::validateIsOfType(dataSet, DataSet)
+  validateIsString(filePath)
+  validateIsOfType(dataSet, DataSet)
   filePath <- expandPath(filePath)
   dataRepositoryTask <- getNetTask("DataRepositoryTask")
   rClr::clrCall(dataRepositoryTask, "SaveDataRepository", dataSet$dataRepository$ref, filePath)
@@ -76,7 +76,7 @@ saveDataSetToPKML <- function(dataSet, filePath) {
 
 dataSetToDataFrame <- function(dataSets) {
   dataSets <- c(dataSets)
-  ospsuite.utils::validateIsOfType(dataSets, DataSet)
+  validateIsOfType(dataSets, DataSet)
 
   # styler: off
   name         <- .makeDataFrameColumn(dataSets, "name")
@@ -141,9 +141,9 @@ dataSetToDataFrame <- function(dataSets) {
 #' )
 #' }
 loadDataSetsFromExcel <- function(xlsFilePath, importerConfiguration, importAllSheets = FALSE) {
-  ospsuite.utils::validateIsString(xlsFilePath)
-  ospsuite.utils::validateIsOfType(importerConfiguration, DataImporterConfiguration)
-  ospsuite.utils::validateIsLogical(importAllSheets)
+  validateIsString(xlsFilePath)
+  validateIsOfType(importerConfiguration, DataImporterConfiguration)
+  validateIsLogical(importAllSheets)
 
   dataImporterTask <- getNetTask("DataImporterTask")
   rClr::clrSet(dataImporterTask, "IgnoreSheetNamesAtImport", importAllSheets)

--- a/R/utilities-entity.R
+++ b/R/utilities-entity.R
@@ -2,7 +2,7 @@
 #'
 #' 
 #' @export
-CompareBy <- ospsuite.utils::enum(c(
+CompareBy <- enum(c(
   "id",
   "name",
   "path"
@@ -12,7 +12,7 @@ CompareBy <- ospsuite.utils::enum(c(
 #'
 #' 
 #' @keywords internal
-AllMatchingMethod <- ospsuite.utils::enum(c(
+AllMatchingMethod <- enum(c(
   Container = "AllContainersMatching",
   Quantity = "AllQuantitiesMatching",
   Parameter = "AllParametersMatching",
@@ -23,7 +23,7 @@ AllMatchingMethod <- ospsuite.utils::enum(c(
 #'
 #' 
 #' @keywords internal
-AllPathsInMethod <- ospsuite.utils::enum(c(
+AllPathsInMethod <- enum(c(
   Container = "AllContainerPathsIn",
   Quantity = "AllQuantityPathsIn",
   Parameter = "AllParameterPathsIn",
@@ -60,7 +60,7 @@ uniqueEntities <- function(entities, compareBy = CompareBy$id) {
   }
 
   entities <- toList(entities)
-  ospsuite.utils::validateIsOfType(entities, Entity)
+  validateIsOfType(entities, Entity)
   validateEnumValue(compareBy, CompareBy)
 
   uniqueEntities <- new.env(parent = emptyenv())
@@ -106,9 +106,9 @@ unify <- function(groupEntitiesByPathFunc, paths) {
 #'
 getAllEntitiesMatching <- function(paths, container, entityType, method = NULL) {
   # Test for correct inputs
-  ospsuite.utils::validateIsOfType(container, c(Simulation, Container, Molecule))
-  ospsuite.utils::validateIsString(paths)
-  ospsuite.utils::validateIsString(method, nullAllowed = TRUE)
+  validateIsOfType(container, c(Simulation, Container, Molecule))
+  validateIsString(paths)
+  validateIsString(method, nullAllowed = TRUE)
   className <- entityType$classname
   if (length(which(names(AllMatchingMethod) == className)) == 0) {
     stop(messages$errorWrongType("entityType", className, names(AllMatchingMethod)))
@@ -134,8 +134,8 @@ getAllEntitiesMatching <- function(paths, container, entityType, method = NULL) 
 #' The list is empty if no entities matching were found.
 #'
 getAllEntityPathsIn <- function(container, entityType, method = NULL) {
-  ospsuite.utils::validateIsOfType(container, c(Simulation, Container, Molecule))
-  ospsuite.utils::validateIsString(method, nullAllowed = TRUE)
+  validateIsOfType(container, c(Simulation, Container, Molecule))
+  validateIsString(method, nullAllowed = TRUE)
   className <- entityType$classname
   if (length(which(names(AllPathsInMethod) == className)) == 0) {
     stop(messages$errorWrongType("entityType", className, names(AllPathsInMethod)))

--- a/R/utilities-molecule.R
+++ b/R/utilities-molecule.R
@@ -85,7 +85,7 @@ getMolecule <- function(path, container, stopIfNotFound = TRUE) {
 #' setMoleculeInitialValues(molecules, c(2, 3), units = c("pmol", "mmol"))
 #' @export
 setMoleculeInitialValues <- function(molecules, values, units = NULL) {
-  ospsuite.utils::validateIsOfType(molecules, Molecule)
+  validateIsOfType(molecules, Molecule)
   setQuantityValues(molecules, values, units)
 }
 
@@ -141,9 +141,9 @@ setMoleculeValuesByPath <- function(moleculePaths, values, simulation, units = N
 #' @export
 setMoleculeScaleDivisors <- function(molecules, values) {
   molecules <- toList(molecules)
-  ospsuite.utils::validateIsOfType(molecules, Molecule)
-  ospsuite.utils::validateIsNumeric(values)
-  ospsuite.utils::validateIsSameLength(molecules, values)
+  validateIsOfType(molecules, Molecule)
+  validateIsNumeric(values)
+  validateIsSameLength(molecules, values)
 
   for (i in seq_along(molecules)) {
     molecule <- molecules[[i]]

--- a/R/utilities-output-schema.R
+++ b/R/utilities-output-schema.R
@@ -25,8 +25,8 @@
 #' addOutputInterval(sim, 10 * 60, 17 * 60, 4 / 60, intervalName = "Second Interval")
 #' @export
 addOutputInterval <- function(simulation, startTime, endTime, resolution, intervalName = NULL) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsNumeric(c(startTime, endTime, resolution))
+  validateIsOfType(simulation, Simulation)
+  validateIsNumeric(c(startTime, endTime, resolution))
   schema <- simulation$outputSchema
   outputIntervalFactory <- getNetTask("OutputIntervalFactory")
   netIntervals <- rClr::clrCall(outputIntervalFactory, "CreateFor", schema$ref, startTime, endTime, resolution)
@@ -73,7 +73,7 @@ setOutputInterval <- function(simulation, startTime, endTime, resolution, interv
 #' clearOutputIntervals(sim)
 #' @export
 clearOutputIntervals <- function(simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(simulation, Simulation)
   simulation$outputSchema$clear()
   invisible(simulation)
 }

--- a/R/utilities-output-selections.R
+++ b/R/utilities-output-selections.R
@@ -20,12 +20,12 @@
 addOutputs <- function(quantitiesOrPaths, simulation) {
   quantitiesOrPaths <- c(quantitiesOrPaths)
 
-  ospsuite.utils::validateIsOfType(quantitiesOrPaths, c(Quantity, "character"))
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(quantitiesOrPaths, c(Quantity, "character"))
+  validateIsOfType(simulation, Simulation)
 
   # If quantities are provided, get their paths
   paths <- vector("character", length(quantitiesOrPaths))
-  if (ospsuite.utils::isOfType(quantitiesOrPaths, Quantity)) {
+  if (isOfType(quantitiesOrPaths, Quantity)) {
     for (idx in seq_along(quantitiesOrPaths)) {
       paths[[idx]] <- quantitiesOrPaths[[idx]]$path
     }
@@ -52,7 +52,7 @@ addOutputs <- function(quantitiesOrPaths, simulation) {
 #' clearOutputs(sim)
 #' @export
 clearOutputs <- function(simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(simulation, Simulation)
   simulation$outputSelections$clear()
   invisible(simulation)
 }

--- a/R/utilities-parameter.R
+++ b/R/utilities-parameter.R
@@ -100,7 +100,7 @@ getParameterDisplayPaths <- function(paths, simulation) {
 #' setParameterValues(params, c(2, 3), units = c("ml", "l"))
 #' @export
 setParameterValues <- function(parameters, values, units = NULL) {
-  ospsuite.utils::validateIsOfType(parameters, Parameter)
+  validateIsOfType(parameters, Parameter)
   setQuantityValues(parameters, values, units)
 }
 
@@ -151,6 +151,6 @@ setParameterValuesByPath <- function(parameterPaths, values, simulation, units =
 #' scaleParameterValues(params, 1.5)
 #' @export
 scaleParameterValues <- function(parameters, factor) {
-  ospsuite.utils::validateIsOfType(parameters, Parameter)
+  validateIsOfType(parameters, Parameter)
   scaleQuantityValues(parameters, factor)
 }

--- a/R/utilities-path.R
+++ b/R/utilities-path.R
@@ -9,7 +9,7 @@
 #' array <- toPathArray("Organism|Organ|Liver")
 #' @export
 toPathArray <- function(path) {
-  ospsuite.utils::validateIsString(path)
+  validateIsString(path)
   unlist(strsplit(path, paste0("\\", ospsuiteEnv$pathSeparator)), use.names = FALSE)
 }
 
@@ -23,6 +23,6 @@ toPathArray <- function(path) {
 #' @export
 toPathString <- function(...) {
   pathStrings <- c(...)
-  ospsuite.utils::validateIsString(pathStrings)
+  validateIsString(pathStrings)
   paste(pathStrings, collapse = ospsuiteEnv$pathSeparator)
 }

--- a/R/utilities-pk-analysis.R
+++ b/R/utilities-pk-analysis.R
@@ -14,7 +14,7 @@
 #' pkAnalyses <- calculatePKAnalyses(results)
 #' @export
 calculatePKAnalyses <- function(results) {
-  ospsuite.utils::validateIsOfType(results, SimulationResults)
+  validateIsOfType(results, SimulationResults)
   pkAnalysisTask <- getNetTask("PKAnalysisTask")
   calculatePKAnalysisArgs <- rClr::clrNew("OSPSuite.R.Services.CalculatePKAnalysisArgs")
   rClr::clrSet(calculatePKAnalysisArgs, "Simulation", results$simulation$ref)
@@ -30,8 +30,8 @@ calculatePKAnalyses <- function(results) {
 #'
 #' @export
 exportPKAnalysesToCSV <- function(pkAnalyses, filePath) {
-  ospsuite.utils::validateIsOfType(pkAnalyses, SimulationPKAnalyses)
-  ospsuite.utils::validateIsString(filePath)
+  validateIsOfType(pkAnalyses, SimulationPKAnalyses)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   pkAnalysisTask <- getNetTask("PKAnalysisTask")
   rClr::clrCall(pkAnalysisTask, "ExportPKAnalysesToCSV", pkAnalyses$ref, pkAnalyses$simulation$ref, filePath)
@@ -51,8 +51,8 @@ savePKAnalysesToCSV <- function(pkAnalyses, filePath) {
 #'
 #' @export
 importPKAnalysesFromCSV <- function(filePath, simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsString(filePath)
+  validateIsOfType(simulation, Simulation)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   pkAnalysisTask <- getNetTask("PKAnalysisTask")
   pkAnalyses <- rClr::clrCall(pkAnalysisTask, "ImportPKAnalysesFromCSV", filePath, simulation$ref)
@@ -66,7 +66,7 @@ importPKAnalysesFromCSV <- function(filePath, simulation) {
 #'
 #' @export
 pkAnalysesAsDataFrame <- function(pkAnalyses) {
-  ospsuite.utils::validateIsOfType(pkAnalyses, SimulationPKAnalyses)
+  validateIsOfType(pkAnalyses, SimulationPKAnalyses)
   pkParameterResultsFilePath <- tempfile()
   dataFrame <- tryCatch(
     {

--- a/R/utilities-pk-parameter.R
+++ b/R/utilities-pk-parameter.R
@@ -28,10 +28,10 @@
 #' myCMax$endApplicationIndex <- 5
 #' @export
 addUserDefinedPKParameter <- function(name, standardPKParameter, displayName = NULL, displayUnit = NULL) {
-  ospsuite.utils::validateIsString(name)
+  validateIsString(name)
   validateEnumValue(standardPKParameter, StandardPKParameter)
-  ospsuite.utils::validateIsString(displayName, nullAllowed = TRUE)
-  ospsuite.utils::validateIsString(displayUnit, nullAllowed = TRUE)
+  validateIsString(displayName, nullAllowed = TRUE)
+  validateIsString(displayUnit, nullAllowed = TRUE)
 
   displayUnit <- encodeUnit(displayUnit %||% "")
   displayName <- enc2utf8(displayName %||% "")

--- a/R/utilities-population.R
+++ b/R/utilities-population.R
@@ -8,7 +8,7 @@
 #' population <- loadPopulation(csvPath)
 #' @export
 loadPopulation <- function(csvPopulationFile) {
-  ospsuite.utils::validateIsString(csvPopulationFile)
+  validateIsString(csvPopulationFile)
   csvPopulationFile <- expandPath(csvPopulationFile)
   populationTask <- getNetTask("PopulationTask")
   population <- rClr::clrCall(populationTask, "ImportPopulation", csvPopulationFile)
@@ -30,10 +30,10 @@ loadPopulation <- function(csvPopulationFile) {
 #' splitFiles <- splitPopulationFile(csvPath, 3, tempdir(), "PopFile")
 #' @export
 splitPopulationFile <- function(csvPopulationFile, numberOfCores, outputFolder, outputFileName) {
-  ospsuite.utils::validateIsString(csvPopulationFile)
-  ospsuite.utils::validateIsNumeric(numberOfCores)
-  ospsuite.utils::validateIsString(outputFolder)
-  ospsuite.utils::validateIsString(outputFileName)
+  validateIsString(csvPopulationFile)
+  validateIsNumeric(numberOfCores)
+  validateIsString(outputFolder)
+  validateIsString(outputFileName)
   csvPopulationFile <- expandPath(csvPopulationFile)
   outputFileName <- enc2utf8(outputFileName)
   populationTask <- getNetTask("PopulationTask")
@@ -52,7 +52,7 @@ splitPopulationFile <- function(csvPopulationFile, numberOfCores, outputFolder, 
 #' df <- populationAsDataFrame(population)
 #' @export
 populationAsDataFrame <- function(population) {
-  ospsuite.utils::validateIsOfType(population, Population)
+  validateIsOfType(population, Population)
   columns <- list()
   columns$IndividualId <- population$allIndividualIds
 
@@ -82,8 +82,8 @@ populationAsDataFrame <- function(population) {
 #' exportPopulationToCSV(population, tempfile())
 #' @export
 exportPopulationToCSV <- function(population, filePath) {
-  ospsuite.utils::validateIsOfType(population, Population)
-  ospsuite.utils::validateIsString(filePath)
+  validateIsOfType(population, Population)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   df <- populationAsDataFrame(population)
   write.csv(df, file = filePath, row.names = FALSE)
@@ -105,7 +105,7 @@ savePopulationToCSV <- function(population, filePath) {
 #' agingData <- loadAgingDataFromCSV(csvPath)
 #' @export
 loadAgingDataFromCSV <- function(filePath) {
-  ospsuite.utils::validateIsString(filePath)
+  validateIsString(filePath)
   df <- readr::read_csv(filePath, locale = readr::locale(encoding = "UTF-8"), comment = "#", col_types = readr::cols())
   agingData <- AgingData$new()
   agingData$individualIds <- as.integer(df$IndividualId)

--- a/R/utilities-quantity.R
+++ b/R/utilities-quantity.R
@@ -94,18 +94,18 @@ setQuantityValues <- function(quantities, values, units = NULL) {
   values <- c(values)
 
   # Test for correct inputs
-  ospsuite.utils::validateIsOfType(quantities, Quantity)
-  ospsuite.utils::validateIsNumeric(values)
+  validateIsOfType(quantities, Quantity)
+  validateIsNumeric(values)
 
   if (length(values) > 1) {
-    ospsuite.utils::validateIsSameLength(quantities, values)
+    validateIsSameLength(quantities, values)
   } else {
     values <- rep(values, length(quantities))
   }
 
   if (!is.null(units)) {
-    ospsuite.utils::validateIsSameLength(quantities, units)
-    ospsuite.utils::validateIsString(units)
+    validateIsSameLength(quantities, units)
+    validateIsString(units)
   }
 
   for (i in seq_along(quantities)) {
@@ -141,14 +141,14 @@ setQuantityValues <- function(quantities, values, units = NULL) {
 #' setParameterValuesByPath(list("Organism|Liver|Volume", "Organism|Liver|A"), c(2, 3), sim)
 #' @export
 setQuantityValuesByPath <- function(quantityPaths, values, simulation, units = NULL, stopIfNotFound = TRUE) {
-  ospsuite.utils::validateIsString(quantityPaths)
-  ospsuite.utils::validateIsNumeric(values)
-  ospsuite.utils::validateIsSameLength(quantityPaths, values)
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsString(quantityPaths)
+  validateIsNumeric(values)
+  validateIsSameLength(quantityPaths, values)
+  validateIsOfType(simulation, Simulation)
 
   if (!is.null(units)) {
-    ospsuite.utils::validateIsSameLength(quantityPaths, units)
-    ospsuite.utils::validateIsString(units)
+    validateIsSameLength(quantityPaths, units)
+    validateIsString(units)
   }
 
   task <- getContainerTask()
@@ -180,8 +180,8 @@ scaleQuantityValues <- function(quantities, factor) {
   quantities <- c(quantities)
 
   # Test for correct inputs
-  ospsuite.utils::validateIsOfType(quantities, Quantity)
-  ospsuite.utils::validateIsNumeric(factor)
+  validateIsOfType(quantities, Quantity)
+  validateIsNumeric(factor)
 
   lapply(quantities, function(q) q$value <- q$value * factor)
   invisible()
@@ -196,8 +196,8 @@ scaleQuantityValues <- function(quantities, factor) {
 #' @return a display path for each entry in paths
 #'
 getQuantityDisplayPaths <- function(paths, simulation) {
-  ospsuite.utils::validateIsString(paths)
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsString(paths)
+  validateIsOfType(simulation, Simulation)
   displayResolver <- getNetTask("FullPathDisplayResolver")
   paths <- c(paths)
 

--- a/R/utilities-sensitivity-analysis.R
+++ b/R/utilities-sensitivity-analysis.R
@@ -16,8 +16,8 @@
 #' results <- runSensitivityAnalysis(sensitivity)
 #' @export
 runSensitivityAnalysis <- function(sensitivityAnalysis, sensitivityAnalysisRunOptions = NULL) {
-  ospsuite.utils::validateIsOfType(sensitivityAnalysis, SensitivityAnalysis)
-  ospsuite.utils::validateIsOfType(sensitivityAnalysisRunOptions, SensitivityAnalysisRunOptions, nullAllowed = TRUE)
+  validateIsOfType(sensitivityAnalysis, SensitivityAnalysis)
+  validateIsOfType(sensitivityAnalysisRunOptions, SensitivityAnalysisRunOptions, nullAllowed = TRUE)
   options <- sensitivityAnalysisRunOptions %||% SensitivityAnalysisRunOptions$new()
   sensitivityAnalysisRunner <- getNetTask("SensitivityAnalysisRunner")
 
@@ -47,8 +47,8 @@ runSensitivityAnalysis <- function(sensitivityAnalysis, sensitivityAnalysisRunOp
 #' exportSensitivityAnalysisResultsToCSV(results, tempfile())
 #' @export
 exportSensitivityAnalysisResultsToCSV <- function(results, filePath) {
-  ospsuite.utils::validateIsOfType(results, SensitivityAnalysisResults)
-  ospsuite.utils::validateIsString(filePath)
+  validateIsOfType(results, SensitivityAnalysisResults)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   sensitivityAnalysisTask <- getNetTask("SensitivityAnalysisTask")
   rClr::clrCall(sensitivityAnalysisTask, "ExportResultsToCSV", results$ref, results$simulation$ref, filePath)
@@ -79,8 +79,8 @@ saveSensitivityAnalysisResultsToCSV <- function(results, filePath) {
 #' results <- importSensitivityAnalysisResultsFromCSV(sim, resultPath)
 #' @export
 importSensitivityAnalysisResultsFromCSV <- function(simulation, filePaths) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsString(filePaths)
+  validateIsOfType(simulation, Simulation)
+  validateIsString(filePaths)
   filePaths <- unlist(lapply(filePaths, function(filePath) expandPath(filePath)))
 
   sensitivityAnalysisTask <- getNetTask("SensitivityAnalysisTask")
@@ -102,7 +102,7 @@ importSensitivityAnalysisResultsFromCSV <- function(simulation, filePaths) {
 #' parameterPaths <- potentialVariableParameterPathsFor(sim)
 #' @export
 potentialVariableParameterPathsFor <- function(simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(simulation, Simulation)
   sensitivityAnalysisTask <- getNetTask("SensitivityAnalysisTask")
   rClr::clrCall(sensitivityAnalysisTask, "PotentialVariableParameterPathsFor", simulation$ref)
 }

--- a/R/utilities-simulation-results.R
+++ b/R/utilities-simulation-results.R
@@ -56,10 +56,10 @@ getOutputValues <- function(simulationResults,
                             individualIds = NULL,
                             stopIfNotFound = TRUE,
                             addMetaData = TRUE) {
-  ospsuite.utils::validateIsOfType(simulationResults, SimulationResults)
-  ospsuite.utils::validateIsOfType(population, Population, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(individualIds, nullAllowed = TRUE)
-  ospsuite.utils::validateIsOfType(quantitiesOrPaths, c(Quantity, "character"), nullAllowed = TRUE)
+  validateIsOfType(simulationResults, SimulationResults)
+  validateIsOfType(population, Population, nullAllowed = TRUE)
+  validateIsNumeric(individualIds, nullAllowed = TRUE)
+  validateIsOfType(quantitiesOrPaths, c(Quantity, "character"), nullAllowed = TRUE)
 
   quantitiesOrPaths <- quantitiesOrPaths %||% simulationResults$allQuantityPaths
   quantitiesOrPaths <- c(quantitiesOrPaths)
@@ -70,7 +70,7 @@ getOutputValues <- function(simulationResults,
 
   # If quantities are provided, get their paths
   paths <- vector("character", length(quantitiesOrPaths))
-  if (ospsuite.utils::isOfType(quantitiesOrPaths, Quantity)) {
+  if (isOfType(quantitiesOrPaths, Quantity)) {
     for (idx in seq_along(quantitiesOrPaths)) {
       paths[[idx]] <- quantitiesOrPaths[[idx]]$path
     }
@@ -156,8 +156,8 @@ getOutputValues <- function(simulationResults,
 #' exportResultsToCSV(results, tempfile())
 #' @export
 exportResultsToCSV <- function(results, filePath) {
-  ospsuite.utils::validateIsOfType(results, SimulationResults)
-  ospsuite.utils::validateIsString(filePath)
+  validateIsOfType(results, SimulationResults)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   simulationResultsTask <- getNetTask("SimulationResultsTask")
   rClr::clrCall(simulationResultsTask, "ExportResultsToCSV", results$ref, results$simulation$ref, filePath)
@@ -187,8 +187,8 @@ saveResultsToCSV <- function(results, filePath) {
 #' results <- importResultsFromCSV(sim, resultPath)
 #' @export
 importResultsFromCSV <- function(simulation, filePaths) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsString(filePaths)
+  validateIsOfType(simulation, Simulation)
+  validateIsString(filePaths)
   simulationResultsTask <- getNetTask("SimulationResultsTask")
   filePaths <- unlist(lapply(filePaths, function(filePath) expandPath(filePath)), use.names = FALSE)
 

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -41,8 +41,8 @@
 #' parameter2$value == parameter3$value # FALSE#'
 #' @export
 loadSimulation <- function(filePath, loadFromCache = FALSE, addToCache = TRUE, resetIds = TRUE) {
-  ospsuite.utils::validateIsLogical(c(loadFromCache, addToCache))
-  ospsuite.utils::validateIsString(filePath)
+  validateIsLogical(c(loadFromCache, addToCache))
+  validateIsString(filePath)
   if (loadFromCache) {
     # If the file has already been loaded, return the last loaded object
     if (ospsuiteEnv$loadedSimulationsCache$hasKey(filePath)) {
@@ -74,8 +74,8 @@ loadSimulation <- function(filePath, loadFromCache = FALSE, addToCache = TRUE, r
 #'
 #' @export
 saveSimulation <- function(simulation, filePath) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsString(filePath)
+  validateIsOfType(simulation, Simulation)
+  validateIsString(filePath)
   filePath <- expandPath(filePath)
   simulationPersister <- getNetTask("SimulationPersister")
   rClr::clrCall(simulationPersister, "SaveSimulation", simulation$ref, filePath)
@@ -160,7 +160,7 @@ runSimulation <- function(simulation, population = NULL, agingData = NULL, simul
 #' @export
 runSimulations <- function(simulations, population = NULL, agingData = NULL, simulationRunOptions = NULL, silentMode = FALSE) {
   simulations <- c(simulations)
-  ospsuite.utils::validateIsOfType(simulationRunOptions, SimulationRunOptions, nullAllowed = TRUE)
+  validateIsOfType(simulationRunOptions, SimulationRunOptions, nullAllowed = TRUE)
   simulationRunOptions <- simulationRunOptions %||% SimulationRunOptions$new()
 
   # only one simulation? We allow population run
@@ -187,16 +187,16 @@ runSimulations <- function(simulations, population = NULL, agingData = NULL, sim
 }
 
 .runSingleSimulation <- function(simulation, simulationRunOptions, population = NULL, agingData = NULL) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(simulation, Simulation)
   if (is.list(population)) {
     # if a list was given as parameter, we assume that the user wants to run a population simulation
     # The population object must be present otherwise, this is an error => nullAllowed is FALSE
     population <- population$population
-    ospsuite.utils::validateIsOfType(population, Population)
+    validateIsOfType(population, Population)
   } else {
-    ospsuite.utils::validateIsOfType(population, Population, nullAllowed = TRUE)
+    validateIsOfType(population, Population, nullAllowed = TRUE)
   }
-  ospsuite.utils::validateIsOfType(agingData, AgingData, nullAllowed = TRUE)
+  validateIsOfType(agingData, AgingData, nullAllowed = TRUE)
   simulationRunner <- getNetTask("SimulationRunner")
   simulationRunArgs <- rClr::clrNew("OSPSuite.R.Services.SimulationRunArgs")
   rClr::clrSet(simulationRunArgs, "Simulation", simulation$ref)
@@ -216,7 +216,7 @@ runSimulations <- function(simulations, population = NULL, agingData = NULL, sim
 }
 
 .runSimulationsConcurrently <- function(simulations, simulationRunOptions, silentMode = FALSE) {
-  ospsuite.utils::validateIsOfType(simulations, Simulation)
+  validateIsOfType(simulations, Simulation)
   simulationRunner <- getNetTask("ConcurrentSimulationRunner")
   rClr::clrSet(simulationRunner, "SimulationRunOptions", simulationRunOptions$ref)
 
@@ -273,20 +273,20 @@ runSimulations <- function(simulations, population = NULL, agingData = NULL, sim
 #' )
 #' @export
 createSimulationBatch <- function(simulation, parametersOrPaths = NULL, moleculesOrPaths = NULL) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsOfType(parametersOrPaths, c(Parameter, "character"), nullAllowed = TRUE)
-  ospsuite.utils::validateIsOfType(moleculesOrPaths, c(Molecule, "character"), nullAllowed = TRUE)
+  validateIsOfType(simulation, Simulation)
+  validateIsOfType(parametersOrPaths, c(Parameter, "character"), nullAllowed = TRUE)
+  validateIsOfType(moleculesOrPaths, c(Molecule, "character"), nullAllowed = TRUE)
 
   if (length(parametersOrPaths) == 0 && length(moleculesOrPaths) == 0) {
     stop(messages$errorSimulationBatchNothingToVary)
   }
   variableParameters <- c(parametersOrPaths)
-  if (ospsuite.utils::isOfType(variableParameters, Parameter)) {
+  if (isOfType(variableParameters, Parameter)) {
     variableParameters <- unlist(lapply(variableParameters, function(x) x$path))
   }
 
   variableMolecules <- c(moleculesOrPaths)
-  if (ospsuite.utils::isOfType(variableMolecules, Molecule)) {
+  if (isOfType(variableMolecules, Molecule)) {
     variableMolecules <- unlist(lapply(variableMolecules, function(x) x$path))
   }
 
@@ -338,10 +338,10 @@ createSimulationBatch <- function(simulation, parametersOrPaths = NULL, molecule
 #' res <- runSimulationBatches(simulationBatches = list(simulationBatch1, simulationBatch2))
 #' }
 runSimulationBatches <- function(simulationBatches, simulationRunOptions = NULL, silentMode = FALSE) {
-  ospsuite.utils::validateIsOfType(simulationBatches, SimulationBatch)
+  validateIsOfType(simulationBatches, SimulationBatch)
   simulationRunner <- getNetTask("ConcurrentSimulationRunner")
   if (!is.null(simulationRunOptions)) {
-    ospsuite.utils::validateIsOfType(simulationRunOptions, SimulationRunOptions)
+    validateIsOfType(simulationRunOptions, SimulationRunOptions)
     rClr::clrSet(simulationRunner, "SimulationRunOptions", simulationRunOptions$ref)
   }
 
@@ -404,7 +404,7 @@ resetSimulationCache <- function() {
 #' removeSimulationFromCache(sim1) # returns TRUE
 #' removeSimulationFromCache(sim2) # returns FALSE
 removeSimulationFromCache <- function(simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(simulation, Simulation)
 
   simulationFilePath <- simulation$sourceFile
 
@@ -444,8 +444,8 @@ removeSimulationFromCache <- function(simulation) {
 #'
 #' parameters <- getStandardMoleculeParameters("CYP3A4", sim1)
 getStandardMoleculeParameters <- function(moleculeName, simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsString(moleculeName)
+  validateIsOfType(simulation, Simulation)
+  validateIsString(moleculeName)
   paths <- sapply(MoleculeParameter, function(p) toPathString(moleculeName, p))
   getAllParametersMatching(paths = paths, container = simulation)
 }
@@ -468,7 +468,7 @@ getStandardMoleculeParameters <- function(moleculeName, simulation) {
 #' params <- getAllParametersForSensitivityAnalysisMatching("Organism|*|Volume", sim)
 #' @export
 getAllParametersForSensitivityAnalysisMatching <- function(paths, simulation) {
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
+  validateIsOfType(simulation, Simulation)
   getAllEntitiesMatching(
     paths = paths,
     container = simulation,
@@ -486,7 +486,7 @@ getAllParametersForSensitivityAnalysisMatching <- function(paths, simulation) {
 #' @return A list of paths
 #' @export
 getAllStateVariablesPaths <- function(simulation) {
-  ospsuite.utils::validateIsOfType(simulation, type = Simulation)
+  validateIsOfType(simulation, type = Simulation)
   allMoleculesPaths <- getAllMoleculePathsIn(container = simulation)
   allStateVariableParamsPaths <- getAllEntityPathsIn(container = simulation, entityType = Parameter, method = "AllStateVariableParameterPathsIn")
   allQantitiesPaths <- append(allMoleculesPaths, allStateVariableParamsPaths)
@@ -512,10 +512,10 @@ getAllStateVariablesPaths <- function(simulation) {
 #' exportIndividualSimulations(population, c(1, 2), tempdir(), sim)
 #' @export
 exportIndividualSimulations <- function(population, individualIds, outputFolder, simulation) {
-  ospsuite.utils::validateIsString(outputFolder)
-  ospsuite.utils::validateIsNumeric(individualIds)
-  ospsuite.utils::validateIsOfType(simulation, Simulation)
-  ospsuite.utils::validateIsOfType(population, Population)
+  validateIsString(outputFolder)
+  validateIsNumeric(individualIds)
+  validateIsOfType(simulation, Simulation)
+  validateIsOfType(population, Population)
   individualIds <- c(individualIds)
   outputFolder <- expandPath(outputFolder)
 

--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -4,7 +4,7 @@
 #' @details Returns `TRUE` if the provided dimension is supported otherwise `FALSE`
 #' @export
 hasDimension <- function(dimension) {
-  ospsuite.utils::validateIsString(dimension)
+  validateIsString(dimension)
   dimensionTask <- getDimensionTask()
   rClr::clrCall(dimensionTask, "HasDimension", enc2utf8(dimension))
 }
@@ -15,7 +15,7 @@ hasDimension <- function(dimension) {
 #' @details Check if the provided dimension is supported. If not, throw an error
 #' @export
 validateDimension <- function(dimension) {
-  ospsuite.utils::validateIsString(dimension)
+  validateIsString(dimension)
   if (!hasDimension(dimension)) {
     stop(messages$errorDimensionNotSupported(dimension))
   }
@@ -28,7 +28,7 @@ validateDimension <- function(dimension) {
 #' @details Check if the unit is valid for the dimension.
 #' @export
 hasUnit <- function(unit, dimension) {
-  ospsuite.utils::validateIsString(unit)
+  validateIsString(unit)
   validateDimension(dimension)
   dimensionTask <- getDimensionTask()
   rClr::clrCall(dimensionTask, "HasUnit", enc2utf8(dimension), encodeUnit(unit))
@@ -77,9 +77,9 @@ getBaseUnit <- function(dimension) {
 #' valuesInBaseUnit <- toBaseUnit(par, c(1000, 2000, 3000), "ml")
 #' @export
 toBaseUnit <- function(quantityOrDimension, values, unit, molWeight = NULL, molWeightUnit = NULL) {
-  ospsuite.utils::validateIsOfType(quantityOrDimension, c(Quantity, "character"))
-  ospsuite.utils::validateIsNumeric(values, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(molWeight, nullAllowed = TRUE)
+  validateIsOfType(quantityOrDimension, c(Quantity, "character"))
+  validateIsNumeric(values, nullAllowed = TRUE)
+  validateIsNumeric(molWeight, nullAllowed = TRUE)
   unit <- encodeUnit(unit)
   dimension <- quantityOrDimension
   dimensionTask <- getNetTask("DimensionTask")
@@ -92,7 +92,7 @@ toBaseUnit <- function(quantityOrDimension, values, unit, molWeight = NULL, molW
   # ensure that we are dealing with an list of values seen as number (and not integer)
   values <- as.numeric(c(values))
 
-  if (ospsuite.utils::isOfType(quantityOrDimension, Quantity)) {
+  if (isOfType(quantityOrDimension, Quantity)) {
     dimension <- quantityOrDimension$dimension
   }
 
@@ -138,9 +138,9 @@ toBaseUnit <- function(quantityOrDimension, values, unit, molWeight = NULL, molW
 #' )
 #' @export
 toUnit <- function(quantityOrDimension, values, targetUnit, molWeight = NULL, sourceUnit = NULL, molWeightUnit = NULL) {
-  ospsuite.utils::validateIsOfType(quantityOrDimension, c(Quantity, "character"))
-  ospsuite.utils::validateIsNumeric(values, nullAllowed = TRUE)
-  ospsuite.utils::validateIsNumeric(molWeight, nullAllowed = TRUE)
+  validateIsOfType(quantityOrDimension, c(Quantity, "character"))
+  validateIsNumeric(values, nullAllowed = TRUE)
+  validateIsNumeric(molWeight, nullAllowed = TRUE)
   targetUnit <- encodeUnit(targetUnit)
   dimension <- quantityOrDimension
   dimensionTask <- getNetTask("DimensionTask")
@@ -155,7 +155,7 @@ toUnit <- function(quantityOrDimension, values, targetUnit, molWeight = NULL, so
     sourceUnit <- encodeUnit(sourceUnit)
   }
 
-  if (ospsuite.utils::isOfType(quantityOrDimension, Quantity)) {
+  if (isOfType(quantityOrDimension, Quantity)) {
     dimension <- quantityOrDimension$dimension
   }
 
@@ -202,7 +202,7 @@ toUnit <- function(quantityOrDimension, values, targetUnit, molWeight = NULL, so
 #' valuesInDisplayUnit <- toDisplayUnit(par, c(1, 5, 5))
 #' @export
 toDisplayUnit <- function(quantity, values) {
-  ospsuite.utils::validateIsOfType(quantity, Quantity)
+  validateIsOfType(quantity, Quantity)
   toUnit(quantity, values, quantity$displayUnit)
 }
 
@@ -224,7 +224,7 @@ allAvailableDimensions <- function() {
 #' dim <- getDimensionForUnit("mg")
 #' @export
 getDimensionForUnit <- function(unit) {
-  ospsuite.utils::validateIsString(unit)
+  validateIsString(unit)
   unit <- encodeUnit(unit)
   dimensionTask <- getDimensionTask()
   dim <- rClr::clrCall(dimensionTask, "DimensionForUnit", unit)
@@ -239,7 +239,7 @@ getDimensionForUnit <- function(unit) {
 #' units <- getUnitsForDimension("Mass")
 #' @export
 getUnitsForDimension <- function(dimension) {
-  ospsuite.utils::validateIsString(dimension)
+  validateIsString(dimension)
   dimensionTask <- getDimensionTask()
   rClr::clrCall(dimensionTask, "AllAvailableUnitNamesFor", enc2utf8(dimension))
 }
@@ -265,7 +265,7 @@ getDimensionTask <- function() {
 #' dim <- getDimensionByName("Time")
 #' @export
 getDimensionByName <- function(name) {
-  ospsuite.utils::validateIsString(name)
+  validateIsString(name)
   dimensionTask <- getDimensionTask()
   rClr::clrCall(dimensionTask, "DimensionByName", enc2utf8(name))
 }
@@ -278,7 +278,7 @@ getUnitsEnum <- function() {
   dimensions <- allAvailableDimensions()
   units <- lapply(dimensions, function(dimension) {
     x <- getUnitsForDimension(dimension = dimension)
-    return(ospsuite.utils::enum(replace(x, x == "", "Unitless")))
+    return(enum(replace(x, x == "", "Unitless")))
   })
   names(units) <- sapply(dimensions, function(str) {
     str <- gsub(pattern = "[(]", replacement = "[", x = str)
@@ -291,7 +291,7 @@ getUnitsEnum <- function() {
 #' @return enum of all dimensions
 #' @keywords internal
 getDimensionsEnum <- function() {
-  ospsuite.utils::enum(allAvailableDimensions())
+  enum(allAvailableDimensions())
 }
 
 #' Supported dimensions defined as a named list

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -8,7 +8,7 @@
 #' @keywords internal
 toObjectType <- function(netObject, class) {
   if (!is.list(netObject)) {
-    return(ospsuite.utils::ifNotNull(netObject, class$new(ref = netObject)))
+    return(ifNotNull(netObject, class$new(ref = netObject)))
   }
   sapply(c(netObject), function(x) {
     class$new(ref = x)

--- a/tests/testthat/test-utilities-data-set.R
+++ b/tests/testthat/test-utilities-data-set.R
@@ -4,7 +4,7 @@ test_that("It can load a valid observed data file and create a DataSet object", 
   file <- getTestDataFilePath("obs_data.pkml")
   dataSet <- loadDataSetFromPKML(file)
 
-  expect_true(ospsuite.utils::isOfType(dataSet, DataSet))
+  expect_true(isOfType(dataSet, DataSet))
 })
 
 context("dataSetToDataFrame")
@@ -165,7 +165,7 @@ test_that("it can load when loading from file with one sheet without
   skip_on_os("linux") # TODO enable again as soon as NPOI runs under Linux; s. https://github.com/Open-Systems-Pharmacology/OSPSuite-R/issues/647
 
   dataSets <- loadDataSetsFromExcel(xlsFilePath = xlsFilePath, importerConfiguration = importerConfiguration, importAllSheets = TRUE)
-  expect_true(ospsuite.utils::isOfType(dataSets, DataSet))
+  expect_true(isOfType(dataSets, DataSet))
   expect_equal(length(dataSets), 4)
 })
 

--- a/tests/testthat/test-utilities-simulation.R
+++ b/tests/testthat/test-utilities-simulation.R
@@ -144,7 +144,7 @@ test_that("It runs one individual simulation without simulationRunOptions", {
 
   sim <- loadTestSimulation("S1", loadFromCache = FALSE)
   results <- runSimulation(simulation = sim)
-  expect_true(ospsuite.utils::isOfType(results, "SimulationResults"))
+  expect_true(isOfType(results, "SimulationResults"))
 })
 
 test_that("It runs one individual simulation with simulationRunOptions", {
@@ -152,7 +152,7 @@ test_that("It runs one individual simulation with simulationRunOptions", {
   sim <- loadTestSimulation("S1", loadFromCache = FALSE)
   simRunOptions <- SimulationRunOptions$new()
   results <- runSimulation(simulation = sim, simulationRunOptions = simRunOptions)
-  expect_true(ospsuite.utils::isOfType(results, "SimulationResults"))
+  expect_true(isOfType(results, "SimulationResults"))
 })
 
 test_that("It runs multiple individual simulations", {
@@ -163,7 +163,7 @@ test_that("It runs multiple individual simulations", {
   expect_equal(length(results), 2)
   # Check the ids
   expect_equal(names(results)[[1]], sim$id)
-  expect_true(ospsuite.utils::isOfType(results[[1]], "SimulationResults"))
+  expect_true(isOfType(results[[1]], "SimulationResults"))
 })
 
 test_that("It shows a warning if one of simulations fails. Results for this simulation are NULL", {
@@ -176,7 +176,7 @@ test_that("It shows a warning if one of simulations fails. Results for this simu
   expect_equal(length(results), 2)
   expect_equal(names(results)[[2]], sim2$id)
   expect_null(results[[sim$id]])
-  expect_true(ospsuite.utils::isOfType(results[[2]], "SimulationResults"))
+  expect_true(isOfType(results[[2]], "SimulationResults"))
 })
 
 test_that("It does not show a warning if one of simulations fails in silent mode. Results for this simulation are NULL", {
@@ -189,7 +189,7 @@ test_that("It does not show a warning if one of simulations fails in silent mode
   expect_equal(length(results), 2)
   expect_equal(names(results)[[2]], sim2$id)
   expect_null(results[[sim$id]])
-  expect_true(ospsuite.utils::isOfType(results[[2]], "SimulationResults"))
+  expect_true(isOfType(results[[2]], "SimulationResults"))
 })
 
 test_that("It throws an error when running multiple simulations with a population", {
@@ -266,7 +266,7 @@ test_that("It can run a simulation batch by varying some parameters and molecule
   id <- simulationBatch$addRunValues(parameterValues = c(1.2, 2.4), initialValues = 2.5)
   res <- runSimulationBatches(simulationBatches = simulationBatch)
   expect_equal(length(res), 1)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
 })
 
 test_that("It can run a simulation batch by varying some parameters only", {
@@ -275,7 +275,7 @@ test_that("It can run a simulation batch by varying some parameters only", {
   id <- simulationBatch$addRunValues(parameterValues = c(1.2, 2.4))
   res <- runSimulationBatches(simulationBatch)
   expect_equal(length(res), 1)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
 })
 
 test_that("It can run a simulation batch by varying some molecule only", {
@@ -284,7 +284,7 @@ test_that("It can run a simulation batch by varying some molecule only", {
   id <- simulationBatch$addRunValues(initialValues = 1.2)
   res <- runSimulationBatches(simulationBatch)
   expect_equal(length(res), 1)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
 })
 
 test_that("The result is NULL when the number of values does not match the initialization count for initial values", {
@@ -322,7 +322,7 @@ test_that("It can run a simulation batch with multiple parameters and molecules 
   res <- runSimulationBatches(simulationBatches = simulationBatch)
 
   expect_equal(length(res), 1)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
   expect_equal(names(res[[1]])[[1]], ids[[1]])
 })
 
@@ -339,7 +339,7 @@ test_that("It can run multiple simulation batches with multiple parameters and m
   ids[[4]] <- simulationBatch2$addRunValues(parameterValues = c(2.6, 4.4), initialValues = 5)
   res <- runSimulationBatches(simulationBatches = list(simulationBatch1, simulationBatch2))
   expect_equal(length(res), 2)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
   expect_equal(names(res[[1]])[[1]], ids[[1]])
   expect_equal(names(res[[1]])[[2]], ids[[2]])
   expect_equal(names(res[[2]])[[1]], ids[[3]])
@@ -356,7 +356,7 @@ test_that("It can run a simulation batch, add new values, and run again", {
   ids[[2]] <- simulationBatch$addRunValues(parameterValues = c(1.6, 2.4), initialValues = 3)
   res <- runSimulationBatches(simulationBatches = simulationBatch)
   expect_equal(length(res), 1)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
   expect_equal(names(res[[1]])[[1]], ids[[1]])
   expect_equal(names(res[[1]])[[2]], ids[[2]])
 
@@ -364,7 +364,7 @@ test_that("It can run a simulation batch, add new values, and run again", {
   ids[[2]] <- simulationBatch$addRunValues(parameterValues = c(1.6, 2.4), initialValues = 3)
   res <- runSimulationBatches(simulationBatches = simulationBatch)
   expect_equal(length(res), 1)
-  expect_true(ospsuite.utils::isOfType(res[[1]][[1]], "SimulationResults"))
+  expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
   expect_equal(names(res[[1]])[[1]], ids[[1]])
   expect_equal(names(res[[1]])[[2]], ids[[2]])
 })


### PR DESCRIPTION
We import the entire utilities package, so :: is not necessary.

Plus each use of :: comes with a penalty of 60 microseconds in performance