### PR TITLE
Add more tests and clean up existing tests for `DataCombined`

### DIFF
--- a/R/data-combined.R
+++ b/R/data-combined.R
@@ -115,6 +115,9 @@ DataCombined <- R6::R6Class(
                                     population = NULL,
                                     individualIds = NULL,
                                     newNames = NULL) {
+      # validate vector arguments' type and length
+      validateIsOfType(simulationResults, "SimulationResults", FALSE)
+
       # A list or a vector of `SimulationResults` class instances is not allowed
       #
       # If we were to allow this, `quantitiesOrPaths`, `population`, and
@@ -137,8 +140,7 @@ DataCombined <- R6::R6Class(
       pathsNames <- quantitiesOrPaths %||% simulationResults$allQuantityPaths
       pathsLength <- length(pathsNames)
 
-      # validate vector arguments' type and length
-      validateIsOfType(simulationResults, "SimulationResults", FALSE)
+      # validate alternative names for their length and type
       newNames <- cleanVectorArgs(newNames, pathsLength, type = "character")
 
       # if alternate names are provided for datasets, use them instead

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -35,28 +35,32 @@ test_that("active bindings are read-only", {
 
   expect_error(
     myCombDat$groupMap <- "x", "readonly"
-    #messages$errorPropertyReadOnly("groupMap")
+    # messages$errorPropertyReadOnly("groupMap")
   )
 
   expect_error(
     myCombDat$names <- "x", "readonly"
-    #messages$errorPropertyReadOnly("names")
+    # messages$errorPropertyReadOnly("names")
   )
 
   expect_error(
     myCombDat$dataTransformations <- "x", "readonly"
-    #messages$errorPropertyReadOnly("dataTransformations")
+    # messages$errorPropertyReadOnly("dataTransformations")
   )
 })
 
 test_that("add* methods error if anything but expected data types are entered", {
   myCombDat <- DataCombined$new()
 
-  expect_error(myCombDat$addSimulationResults(list("x", "y")))
-  expect_error(myCombDat$addSimulationResults(list(NULL)))
+  expect_error(
+    myCombDat$addSimulationResults(list("x", "y")),
+    "argument 'simulationResults' is of type 'list', but expected 'SimulationResults'"
+  )
 
-  expect_error(myCombDat$addDataSets(list(1, 2)))
-  expect_error(myCombDat$addDataSets(list(NULL)))
+  expect_error(
+    myCombDat$addDataSets(list(1, 2)),
+    "argument 'dataSets' is of type 'list', but expected 'DataSet'"
+  )
 })
 
 # only `DataSet` ---------------------------------------
@@ -187,21 +191,31 @@ test_that("with no grouping specified, group column in dataframe is `NA`", {
   expect_equal(rep(NA_character_, length(df$group)), df$group)
 })
 
+
+test_that("grouping specification fails when there are no datasets present", {
+  myCombDat <- DataCombined$new()
+
+  expect_error(
+    myCombDat$setGroups(list()),
+    "There are currently no datasets to be grouped."
+  )
+})
+
 test_that("empty grouping specification fails", {
   myCombDat <- DataCombined$new()
   myCombDat$addSimulationResults(simResults)
 
-  expect_error(myCombDat$setGroups(list()))
+  expect_error(
+    myCombDat$setGroups(list()),
+    "You need to provide a named list with at least one valid grouping."
+  )
 })
 
 test_that("setting groups fails when group specification is invalid", {
   myCombDat <- DataCombined$new()
   myCombDat$addDataSets(dataSet)
 
-  expect_error(
-    myCombDat$setGroups(c(2, 4)),
-    "You need to provide a named list with at least one valid grouping."
-  )
+  expect_error(myCombDat$setGroups(c(2, 4)))
 
   expect_error(
     myCombDat$setGroups(list("x" = 2, "y" = 4)),

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -984,8 +984,8 @@ test_that("dataframe output is as expected when only `DataSet` with metadata is 
     c(
       "name", "group", "dataType", "xValues", "xUnit", "xDimension",
       "yValues", "yUnit", "yDimension", "yErrorValues", "yErrorType",
-      "yErrorUnit", "molWeight", "lloq", "Source", "Sheet",
-      "Organ", "Compartment", "Molecule", "Group Id"
+      "yErrorUnit", "molWeight", "lloq", "Source", "Sheet", "Group Id",
+      "Organ", "Compartment", "Species"
     )
   )
 

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -20,7 +20,7 @@ dataSet2 <- loadDataSetsFromExcel(
 )
 
 # dataset with metadata
-myDataSet <- dataSet$Stevens_2012_placebo.Placebo_total
+myDataSet <- dataSet$Stevens_2012_placebo.Placebo_total$clone(deep = TRUE)
 myDataSet$addMetaData("Organ", "Liver")
 myDataSet$addMetaData("Compartment", "Intracellular")
 myDataSet$addMetaData("Species", "Human")

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -34,18 +34,21 @@ test_that("active bindings are read-only", {
   myCombDat <- DataCombined$new()
 
   expect_error(
-    myCombDat$groupMap <- "x", "readonly"
-    # messages$errorPropertyReadOnly("groupMap")
+    myCombDat$groupMap <- "x",
+    messages$errorPropertyReadOnly("groupMap"),
+    fixed = TRUE
   )
 
   expect_error(
-    myCombDat$names <- "x", "readonly"
-    # messages$errorPropertyReadOnly("names")
+    myCombDat$names <- "x",
+    messages$errorPropertyReadOnly("names"),
+    fixed = TRUE
   )
 
   expect_error(
-    myCombDat$dataTransformations <- "x", "readonly"
-    # messages$errorPropertyReadOnly("dataTransformations")
+    myCombDat$dataTransformations <- "x",
+    messages$errorPropertyReadOnly("dataTransformations"),
+    fixed = TRUE
   )
 })
 

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -19,6 +19,12 @@ dataSet2 <- loadDataSetsFromExcel(
   importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath("ImporterConfiguration.xml"))
 )
 
+# dataset with metadata
+myDataSet <- dataSet$Stevens_2012_placebo.Placebo_total
+myDataSet$addMetaData("Organ", "Liver")
+myDataSet$addMetaData("Compartment", "Intracellular")
+myDataSet$addMetaData("Species", "Human")
+
 test_that("active bindings should all be NULL for empty initialization", {
   myCombDat <- DataCombined$new()
 
@@ -68,7 +74,7 @@ test_that("data transformations work as expected when only `DataSet` is provided
   )
 })
 
-test_that("data frame output is as expected when only `DataSet` is provided", {
+test_that("dataframe output is as expected when only `DataSet` is provided", {
   myCombDat <- DataCombined$new()
   myCombDat$addDataSets(dataSet[[1]])
 
@@ -86,6 +92,23 @@ test_that("data frame output is as expected when only `DataSet` is provided", {
   )
   expect_equal(rep(NA_character_, length(df$group)), df$group)
   expect_equal(unique(df$name), names(dataSet)[[1]])
+})
+
+test_that("dataframe output is as expected when only `DataSet` with metadata is provided", {
+  myCombDat <- DataCombined$new()
+  myCombDat$addDataSets(myDataSet)
+  df <- myCombDat$toDataFrame()
+
+  expect_equal(dim(df), c(12L, 21L))
+  expect_equal(
+    names(df),
+    c(
+      "name", "group", "dataType", "xValues", "xUnit", "xDimension",
+      "yValues", "yUnit", "yDimension", "yErrorValues", "yErrorType",
+      "yErrorUnit", "molWeight", "lloq", "Source", "Sheet",
+      "Organ", "Compartment", "Molecule", "Group Id"
+    )
+  )
 })
 
 test_that("data transformations work as expected when only `SimulationResults` is provided", {
@@ -238,7 +261,7 @@ test_that("specifying groupings and new names for only few paths in `SimulationR
   )
 })
 
-test_that("data frame output as expected when only `SimulationResults` is provided", {
+test_that("dataframe output as expected when only `SimulationResults` is provided", {
   myCombDat <- DataCombined$new()
   myCombDat$addSimulationResults(simResults)
 

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -19,12 +19,6 @@ dataSet2 <- loadDataSetsFromExcel(
   importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath("ImporterConfiguration.xml"))
 )
 
-# dataset with metadata
-myDataSet <- dataSet$Stevens_2012_placebo.Placebo_total$clone(deep = TRUE)
-myDataSet$addMetaData("Organ", "Liver")
-myDataSet$addMetaData("Compartment", "Intracellular")
-myDataSet$addMetaData("Species", "Human")
-
 test_that("active bindings should all be NULL for empty initialization", {
   myCombDat <- DataCombined$new()
 
@@ -92,23 +86,6 @@ test_that("dataframe output is as expected when only `DataSet` is provided", {
   )
   expect_equal(rep(NA_character_, length(df$group)), df$group)
   expect_equal(unique(df$name), names(dataSet)[[1]])
-})
-
-test_that("dataframe output is as expected when only `DataSet` with metadata is provided", {
-  myCombDat <- DataCombined$new()
-  myCombDat$addDataSets(myDataSet)
-  df <- myCombDat$toDataFrame()
-
-  expect_equal(dim(df), c(12L, 21L))
-  expect_equal(
-    names(df),
-    c(
-      "name", "group", "dataType", "xValues", "xUnit", "xDimension",
-      "yValues", "yUnit", "yDimension", "yErrorValues", "yErrorType",
-      "yErrorUnit", "molWeight", "lloq", "Source", "Sheet",
-      "Organ", "Compartment", "Molecule", "Group Id"
-    )
-  )
 })
 
 test_that("data transformations work as expected when only `SimulationResults` is provided", {
@@ -988,4 +965,31 @@ test_that("edge cases - groups name same as dataset name", {
 
   # with single datasets the renaming should still work
   expect_equal(myCombDat$groupMap$name, c("b", "a"))
+})
+
+# dataset with metadata
+myDataSet <- dataSet$Stevens_2012_placebo.Placebo_total
+myDataSet$addMetaData("Organ", "Liver")
+myDataSet$addMetaData("Compartment", "Intracellular")
+myDataSet$addMetaData("Species", "Human")
+
+test_that("dataframe output is as expected when only `DataSet` with metadata is provided", {
+  myCombDat <- DataCombined$new()
+  myCombDat$addDataSets(myDataSet)
+  df <- myCombDat$toDataFrame()
+
+  expect_equal(dim(df), c(12L, 21L))
+  expect_equal(
+    names(df),
+    c(
+      "name", "group", "dataType", "xValues", "xUnit", "xDimension",
+      "yValues", "yUnit", "yDimension", "yErrorValues", "yErrorType",
+      "yErrorUnit", "molWeight", "lloq", "Source", "Sheet",
+      "Organ", "Compartment", "Molecule", "Group Id"
+    )
+  )
+
+  expect_equal(unique(df$Organ), "Liver")
+  expect_equal(unique(df$Compartment), "Intracellular")
+  expect_equal(unique(df$Species), "Human")
 })


### PR DESCRIPTION
- closes #785
- adds visual markers to navigate the file more easily
- brings more granularity to tests where, to the best this is possible, each test is about just one thing
- exact error messages are also checked