### PR TITLE
remove vector depth check

### DIFF
--- a/R/data-combined.R
+++ b/R/data-combined.R
@@ -197,9 +197,6 @@ DataCombined <- R6::R6Class(
         stop("You need to provide a named list with at least one valid grouping.")
       }
 
-      # validate depth of the argument vector
-      validateVecDepth(groups)
-
       # Existing grouping can be removed by setting dataset name to `NA`, but
       # since the default `NA` type in R is `logical`, it needs to be converted
       # to `character` type first.

--- a/R/utilities-data-combined.R
+++ b/R/utilities-data-combined.R
@@ -69,9 +69,6 @@ cleanVectorArgs <- function(arg = NULL, expectedLength = NULL, type) {
     validateIsOfLength(arg, expectedLength)
   }
 
-  # validate depth of the vector
-  validateVecDepth(arg)
-
   # convert `NULL`s or logical `NA`s to `NA` of required type
 
   # Note that `purrr::map()` will return a list
@@ -156,39 +153,4 @@ toMissingOfType <- function(x, type) {
   }
 
   return(x)
-}
-
-#' Check if the vector depth is as expected
-#'
-#' @param x A vector whose depth needs to be checked.
-#'
-#' @description
-#'
-#' For function arguments that accept a vector, a vector with depth greater than
-#' 2 is rarely acceptable. This function will produce an error if this is the
-#' case.
-#'
-#' Vector depths:
-#
-# 1 = atomic vector (or empty list)
-# 2 = non-nested list
-# > 2 = nested list
-#'
-#' @examples
-#'
-#' validateVecDepth(c(1)) # depth is 1
-#' validateVecDepth(list()) # depth is 1
-#' validateVecDepth(list(1)) # depth is 2
-#'
-#' # this will produce an error
-#' # validateVecDepth(list(list(1))) # depth is 3
-#' @keywords internal
-#' @noRd
-validateVecDepth <- function(x) {
-  if (purrr::vec_depth(x) > 2L) {
-    stop(
-      "A nested list is not a valid argument here.",
-      call. = FALSE
-    )
-  }
 }

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -226,16 +226,6 @@ test_that("setting groups fails when group specification is invalid", {
   )
 })
 
-test_that("setting groups fails when group specification is in a nested list", {
-  myCombDat <- DataCombined$new()
-  myCombDat$addDataSets(dataSet)
-
-  expect_error(
-    myCombDat$setGroups(list("m" = list("x" = "2", "y" = "4"))),
-    "A nested list is not a valid argument here."
-  )
-})
-
 test_that("setting groups fails when group specification is same for multiple datsets", {
   myCombDat <- DataCombined$new()
   myCombDat$addDataSets(dataSet)


### PR DESCRIPTION
Because:

- it is exceedingly unlikely that users would enter a nested list accidentally
- #853 makes this check completely unnecessary