### PR TITLE
use expect_error instead of throws

### DIFF
--- a/tests/testthat/test-container.R
+++ b/tests/testthat/test-container.R
@@ -30,19 +30,19 @@ test_that("It can retrieve the fullPath of a container", {
 
 test_that("It throws an error when trying to set the path of a container", {
   container <- getContainer(liverPath, sim)
-  expect_that(container$path <- "TOTO", throws_error())
+  expect_error(container$path <- "TOTO")
 })
 
 
 test_that("It throws an error when trying to set the id of a container", {
   container <- getContainer(liverPath, sim)
-  expect_that(container$id <- "id", throws_error())
+  expect_error(container$id <- "id")
 })
 
 
 test_that("It throws an error when trying to set the name of a container", {
   container <- getContainer(liverPath, sim)
-  expect_that(container$name <- "name", throws_error())
+  expect_error(container$name <- "name")
 })
 
 test_that("It can print container", {

--- a/tests/testthat/test-create-population.R
+++ b/tests/testthat/test-create-population.R
@@ -62,7 +62,7 @@ test_that("It throwns an error when creating a human with population missing", {
     species = Species$Human,
     numberOfIndividuals = 10,
   )
-  expect_that(createPopulation(populationCharacteristics = human), throws_error())
+  expect_error(createPopulation(populationCharacteristics = human))
 })
 
 

--- a/tests/testthat/test-molecule-ontogeny.R
+++ b/tests/testthat/test-molecule-ontogeny.R
@@ -6,5 +6,5 @@ test_that("It can create a molecule ontogeny for a predefined ontogeny", {
 })
 
 test_that("It throws an error when creating a molecule ontogeny for an unknown ontogeny", {
-  expect_that(MoleculeOntogeny$new(molecule = "MyMolecule", ontogeny = "Unknown"), throws_error())
+  expect_error(MoleculeOntogeny$new(molecule = "MyMolecule", ontogeny = "Unknown"))
 })

--- a/tests/testthat/test-parameter.R
+++ b/tests/testthat/test-parameter.R
@@ -59,7 +59,7 @@ test_that("It can override a formula with a value", {
 })
 
 test_that("It throws an error when trying to set the name of a parameter", {
-  expect_that(volumeParameter$name <- "TOTO", throws_error())
+  expect_error(volumeParameter$name <- "TOTO")
 })
 
 test_that("It can retrieve the id of a parameter", {
@@ -75,11 +75,11 @@ test_that("It can retrieve the path of a parameter", {
 })
 
 test_that("It throws an error when trying to set the path of a parameter", {
-  expect_that(volumeParameter$path <- "TOTO", throws_error())
+  expect_error(volumeParameter$path <- "TOTO")
 })
 
 test_that("It throws an error when trying to set the id of a parameter", {
-  expect_that(volumeParameter$id <- "id", throws_error())
+  expect_error(volumeParameter$id <- "id")
 })
 
 test_that("It can retrieve a value and update a value of a parameter", {
@@ -97,7 +97,7 @@ test_that("It can retrieve the unit of a parameter", {
 })
 
 test_that("It throws an error when setting the unit of a parameter", {
-  expect_that(volumeParameter$unit <- "ml", throws_error())
+  expect_error(volumeParameter$unit <- "ml")
 })
 
 test_that("It can retrieve the display unit of a parameter", {
@@ -105,7 +105,7 @@ test_that("It can retrieve the display unit of a parameter", {
 })
 
 test_that("It throws an error when setting the display unit of a parameter", {
-  expect_that(volumeParameter$displayUnit <- "ml", throws_error())
+  expect_error(volumeParameter$displayUnit <- "ml")
 })
 
 test_that("It can set a value in another unit and the value will be updated as expected", {
@@ -126,7 +126,7 @@ test_that("It can set a value without the unit specified, thus using the default
 })
 
 test_that("It throws an exception when setting a value in a unit that does not exists", {
-  expect_that(volumeParameter$setValue(1, "kg"), throws_error())
+  expect_error(volumeParameter$setValue(1, "kg"))
 })
 
 test_that("it can retrieve all units defined for a quantity", {
@@ -161,7 +161,7 @@ test_that("It can set the isStateVariable to false for a parameter without RHS",
 
 test_that("It throws an exception when setting the isStateVariable to true for a parameter that has no state variable", {
   par <- getParameter(volumePath, sim)
-  expect_that(par$isStateVariable <- TRUE, throws_error())
+  expect_error(par$isStateVariable <- TRUE)
 })
 
 test_that("It can set the isStateVariable to true for a parameter with RHS", {

--- a/tests/testthat/test-population.R
+++ b/tests/testthat/test-population.R
@@ -77,7 +77,7 @@ test_that("It can remove user defined variability", {
 test_that("It throws an exception when adding values that have the wrong number of items", {
   population <- loadPopulation(populationFileName)
   parameterPath <- "Organism|MyParameter"
-  expect_that(population$setParameterValues(parameterPath, c(1:5) * 2.5), throws_error())
+  expect_error(population$setParameterValues(parameterPath, c(1:5) * 2.5))
 })
 
 test_that("It can retrieve all parameter values for an existing individual id", {
@@ -90,7 +90,7 @@ test_that("It can retrieve all parameter values for an existing individual id", 
 
 test_that("It throws an exception when retrieving all parameter values for an individual id that does not exist", {
   population <- loadPopulation(populationFileName)
-  expect_that(parameterValues <- population$getParameterValuesForIndividual(666), throws_error())
+  expect_error(parameterValues <- population$getParameterValuesForIndividual(666))
 })
 
 context("Covariates")

--- a/tests/testthat/test-sensitivity-analysis.R
+++ b/tests/testthat/test-sensitivity-analysis.R
@@ -17,7 +17,7 @@ test_that("It can create a sensitivity analysis for a given simulation with parm
 
 test_that("The parameter paths property is readonly", {
   sa <- SensitivityAnalysis$new(simple, parameterPaths = c("A", "B"))
-  expect_that(sa$parameterPaths <- c("D"), throws_error())
+  expect_error(sa$parameterPaths <- c("D"))
 })
 
 test_that("It can add a single parameter path", {

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -9,7 +9,7 @@ test_that("It can retrieve the file source of the simulation", {
 })
 
 test_that("It throws an error when trying to set file source", {
-  expect_that(sim$sourceFile <- "TOTO", throws_error())
+  expect_error(sim$sourceFile <- "TOTO")
 })
 
 test_that("It can print the simulation", {

--- a/tests/testthat/test-table-formula.R
+++ b/tests/testthat/test-table-formula.R
@@ -37,7 +37,7 @@ test_that("It can remove a point from the table defined with existing x and y", 
 
 test_that("It throws an exception when trying to add a point at an existing x with a different y", {
   tableFormula$addPoints(20, 30)
-  expect_that(tableFormula$add(20, 40), throws_error())
+  expect_error(tableFormula$add(20, 40))
 })
 
 test_that("It can update the restart solver flag of a given point", {

--- a/tests/testthat/test-utilities-container.R
+++ b/tests/testthat/test-utilities-container.R
@@ -43,11 +43,11 @@ test_that("It returns an empty list when no container was found", {
 })
 
 test_that("It throws an error when no valid container is provided", {
-  expect_that(containers <- getAllContainersMatching(toPathString(c("Organism", "**", "Interstitial")), NULL), throws_error())
+  expect_error(containers <- getAllContainersMatching(toPathString(c("Organism", "**", "Interstitial")), NULL))
 })
 
 test_that("It throws an error when no valid path is provided", {
-  expect_that(containers <- getAllContainersMatching(NULL, sim), throws_error())
+  expect_error(containers <- getAllContainersMatching(NULL, sim))
 })
 
 context("getAllContainerPathsIn")
@@ -79,9 +79,9 @@ test_that("It throws an error if the container by path does not exist", {
 })
 
 test_that("It throws an error when trying to retrieve a container by path that would result in multiple containers", {
-  expect_that(getContainer(toPathString(c("Organism", "*")), sim), throws_error())
+  expect_error(getContainer(toPathString(c("Organism", "*")), sim))
 })
 
 test_that("It throws an error when no valid container is provided", {
-  expect_that(getContainer(toPathString(c("Organism", "*")), "sim"), throws_error())
+  expect_error(getContainer(toPathString(c("Organism", "*")), "sim"))
 })

--- a/tests/testthat/test-utilities-molecule.R
+++ b/tests/testthat/test-utilities-molecule.R
@@ -42,19 +42,19 @@ test_that("It can retrieve all molecule paths defined in a container", {
 context("setMoleculeInitialValues")
 
 test_that("It throws an error when no valid molecule objects are provided", {
-  expect_that(setMoleculeInitialValues("quantity", 1), throws_error())
+  expect_error(setMoleculeInitialValues("quantity", 1))
 })
 
 test_that("It throws an error when no valid values are provided", {
   molecules <- getAllMoleculesMatching("Organism|VenousBlood|Plasma|Caffeine", sim)
-  expect_that(setMoleculeInitialValues(molecules, "s"), throws_error())
+  expect_error(setMoleculeInitialValues(molecules, "s"))
 })
 
 test_that("It throws an error when the number of quantity differs from the number of values", {
   molecule <- getMolecule("Organism|VenousBlood|Plasma|Caffeine", sim)
   molecules <- getAllMoleculesMatching("Organism|VenousBlood|*|Caffeine", sim)
-  expect_that(setMoleculeInitialValues(molecule, c(1, 2)), throws_error())
-  expect_that(setMoleculeInitialValues(molecules, c(1:5)), throws_error())
+  expect_error(setMoleculeInitialValues(molecule, c(1, 2)))
+  expect_error(setMoleculeInitialValues(molecules, c(1:5)))
 })
 
 test_that("It can set the value of a single quantity", {
@@ -75,19 +75,19 @@ test_that("It can set the values of multiple molecules", {
 context("setMoleculeScaleDivisors")
 
 test_that("It throws an error when no valid molecule objects are provided", {
-  expect_that(setMoleculeScaleDivisors("quantity", 1), throws_error())
+  expect_error(setMoleculeScaleDivisors("quantity", 1))
 })
 
 test_that("It throws an error when no valid values are provided", {
   molecules <- getAllMoleculesMatching("Organism|VenousBlood|Plasma|Caffeine", sim)
-  expect_that(setMoleculeScaleDivisors(molecules, "s"), throws_error())
+  expect_error(setMoleculeScaleDivisors(molecules, "s"))
 })
 
 test_that("It throws an error when the number of molecules differs from the number of values", {
   molecule <- getMolecule("Organism|VenousBlood|Plasma|Caffeine", sim)
   molecules <- getAllMoleculesMatching("Organism|VenousBlood|*|Caffeine", sim)
-  expect_that(setMoleculeScaleDivisors(molecule, c(1, 2)), throws_error())
-  expect_that(setMoleculeScaleDivisors(molecules, c(1:5)), throws_error())
+  expect_error(setMoleculeScaleDivisors(molecule, c(1, 2)))
+  expect_error(setMoleculeScaleDivisors(molecules, c(1:5)))
 })
 
 test_that("It can set the scale divisor of a single quantity", {

--- a/tests/testthat/test-utilities-output-schema.R
+++ b/tests/testthat/test-utilities-output-schema.R
@@ -33,7 +33,7 @@ test_that("It uses the property specified to create the interval", {
 test_that("It throws an exception when adding two intervals with the same name", {
   clearOutputIntervals(sim)
   int1 <- addOutputInterval(sim, 10, 20, 1, intervalName = "int")
-  expect_that(addOutputInterval(sim, 10, 20, 1, intervalName = "int"), throws_error())
+  expect_error(addOutputInterval(sim, 10, 20, 1, intervalName = "int"))
 })
 
 

--- a/tests/testthat/test-utilities-output-selections.R
+++ b/tests/testthat/test-utilities-output-selections.R
@@ -36,10 +36,10 @@ test_that("It can add single output by reference", {
 test_that("It throws an exception if the parameters do not have the expect type", {
   parameter <- getParameter("Organism|Liver|Volume", sim)
   container <- getContainer("Organism|Liver", sim)
-  expect_that(addOutputs(sim, parameter), throws_error())
-  expect_that(addOutputs(parameter, container), throws_error())
-  expect_that(addOutputs(parameter, null), throws_error())
-  expect_that(addOutputs(null, sim), throws_error())
+  expect_error(addOutputs(sim, parameter))
+  expect_error(addOutputs(parameter, container))
+  expect_error(addOutputs(parameter, null))
+  expect_error(addOutputs(null, sim))
 })
 
 

--- a/tests/testthat/test-utilities-parameter.R
+++ b/tests/testthat/test-utilities-parameter.R
@@ -43,11 +43,11 @@ test_that("It returns an empty list when no parameter was found", {
 })
 
 test_that("It throws an error when no valid container is provided", {
-  expect_that(parameters <- getAllParametersMatching(toPathString(c("Organism", "Liver", "Intracellular", "Volume")), NULL), throws_error())
+  expect_error(parameters <- getAllParametersMatching(toPathString(c("Organism", "Liver", "Intracellular", "Volume")), NULL))
 })
 
 test_that("It throws an error when no valid path is provided", {
-  expect_that(parameters <- getAllParametersMatching(NULL, sim), throws_error())
+  expect_error(parameters <- getAllParametersMatching(NULL, sim))
 })
 
 context("getAllParameterPathsIn")
@@ -79,33 +79,33 @@ test_that("It throws an error if the parameter by path does not exist", {
 })
 
 test_that("It throws an error when trying to retrieve a parameter by path that would result in multiple parameters", {
-  expect_that(getParameter(toPathString(c("Organism", "Liver", "*")), sim), throws_error())
+  expect_error(getParameter(toPathString(c("Organism", "Liver", "*")), sim))
 })
 
 context("setParameterValues")
 
 test_that("It throws an error when no valid parameter objects are provided", {
-  expect_that(setParameterValues("parameter", 1), throws_error())
+  expect_error(setParameterValues("parameter", 1))
   parameters <- c(getAllParametersMatching(toPathString(c("Organism", "Liver", "*", "Volume")), sim), "1")
-  expect_that(setParameterValues(parameters, 1), throws_error())
+  expect_error(setParameterValues(parameters, 1))
 })
 
 test_that("It throws an error when no valid values are provided", {
   parameter <- getParameter(toPathString(c("Organism", "Liver", "Intracellular", "Volume")), sim)
-  expect_that(setParameterValues(parameter, "s"), throws_error())
+  expect_error(setParameterValues(parameter, "s"))
 })
 
 test_that("It throws an error when the number of parameters differs from the number of values", {
   parameter <- getParameter(toPathString(c("Organism", "Liver", "Intracellular", "Volume")), sim)
   parameters <- getAllParametersMatching(toPathString(c("Organism", "Liver", "*", "Volume")), sim)
-  expect_that(setParameterValues(parameter, c(1, 2)), throws_error())
-  expect_that(setParameterValues(parameters, c(1:5)), throws_error())
+  expect_error(setParameterValues(parameter, c(1, 2)))
+  expect_error(setParameterValues(parameters, c(1:5)))
 })
 
 test_that("It throws an error when the number of parameters differs from the number units", {
   parameter <- getParameter(toPathString(c("Organism", "Liver", "Intracellular", "Volume")), sim)
   parameters <- getAllParametersMatching(toPathString(c("Organism", "Liver", "*", "Volume")), sim)
-  expect_that(setParameterValues(parameters = parameters, values = c(1:6), units = c("l", "ml")), throws_error())
+  expect_error(setParameterValues(parameters = parameters, values = c(1:6), units = c("l", "ml")))
 })
 
 test_that("It can set the value of a single parameter", {
@@ -171,7 +171,7 @@ test_that("It can set multiple parameter values", {
 test_that("It throws an exception when setting values for a parameter that does not exist", {
   sim <- loadTestSimulation("S1", loadFromCache = TRUE)
   parameterPath1 <- "Organism|Liver|NOPE|Volume"
-  expect_that(setParameterValuesByPath(parameterPath, 100, sim), throws_error())
+  expect_error(setParameterValuesByPath(parameterPath, 100, sim))
 })
 
 test_that("It can get the value of an individual from a population and set them into a simulation", {

--- a/tests/testthat/test-utilities-path.R
+++ b/tests/testthat/test-utilities-path.R
@@ -5,7 +5,7 @@ test_that("It should convert a valid path to array", {
 })
 
 test_that("It should throw an error if the argument is not a string ", {
-  expect_that(toPathArray(function() {}), throws_error())
+  expect_error(toPathArray(function() {}))
 })
 
 
@@ -17,5 +17,5 @@ test_that("It should convert a valid path array to string", {
 })
 
 test_that("It should throw an error if the argument is not a string ", {
-  expect_that(toPathString(function() {}), throws_error())
+  expect_error(toPathString(function() {}))
 })

--- a/tests/testthat/test-utilities-population.R
+++ b/tests/testthat/test-utilities-population.R
@@ -8,7 +8,7 @@ test_that("It can load a valid csv population file", {
 
 test_that("It throws an exception when loading an invalid population file", {
   populationFileName <- getTestDataFilePath("junk.csv")
-  expect_that(loadPopulation(populationFileName), throws_error())
+  expect_error(loadPopulation(populationFileName))
 })
 
 

--- a/tests/testthat/test-utilities-sensitivity-analysis.R
+++ b/tests/testthat/test-utilities-sensitivity-analysis.R
@@ -42,10 +42,10 @@ test_that("It can import valid simulation results from multiple CSV files", {
 
 test_that("It throws an exception if the file imported are not valid results file", {
   junkFile <- getTestDataFilePath("pop.csv")
-  expect_that(importSensitivityAnalysisResultsFromCSV(sim, junkFile), throws_error())
+  expect_error(importSensitivityAnalysisResultsFromCSV(sim, junkFile))
 })
 
 test_that("It throws an exception when importing a valid result file that would result in duplicated results", {
   sa1_file <- getTestDataFilePath("sa_1.csv")
-  expect_that(importSensitivityAnalysisResultsFromCSV(sim, c(sa1_file, sa1_file)), throws_error())
+  expect_error(importSensitivityAnalysisResultsFromCSV(sim, c(sa1_file, sa1_file)))
 })

--- a/tests/testthat/test-utilities-simulation-results.R
+++ b/tests/testthat/test-utilities-simulation-results.R
@@ -124,13 +124,13 @@ test_that("It can import valid simulation results from multiple CSV files", {
 
 test_that("It throws an exception if the file imported are not valid results file", {
   junkFile <- getTestDataFilePath("pop.csv")
-  expect_that(importResultsFromCSV(sim, junkFile), throws_error())
+  expect_error(importResultsFromCSV(sim, junkFile))
 })
 
 test_that("It throws an exception when importing a valid result file that does not match the simulation", {
   otherSim <- loadTestSimulation("simple")
   resFile <- getTestDataFilePath("res_10.csv")
-  expect_that(importResultsFromCSV(otherSim, resFile), throws_error())
+  expect_error(importResultsFromCSV(otherSim, resFile))
 })
 
 

--- a/tests/testthat/test-utilities-simulation.R
+++ b/tests/testthat/test-utilities-simulation.R
@@ -16,7 +16,7 @@ test_that("It throws an exception when trying to export for an individual id tha
   populationFileName <- getTestDataFilePath(fileName = "pop.csv")
   population <- loadPopulation(csvPopulationFile = populationFileName)
   sim <- loadTestSimulation(simulationName = "S1", loadFromCache = FALSE)
-  expect_that(exportIndividualSimulations(population = population, individualIds = c(50, 2), outputFolder = tempdir(), simulation = sim), throws_error())
+  expect_error(exportIndividualSimulations(population = population, individualIds = c(50, 2), outputFolder = tempdir(), simulation = sim))
 })
 
 context("loadSimulation")
@@ -136,7 +136,7 @@ test_that("It throws an exception when running a population simulation with the 
   populationFileName <- getTestDataFilePath("pop.csv")
   population <- loadPopulation(csvPopulationFile = populationFileName)
   sim <- loadTestSimulation("S1", loadFromCache = TRUE)
-  expect_that(runSimulation(simulation = population, population = simulation), throws_error())
+  expect_error(runSimulation(simulation = population, population = simulation))
 })
 
 test_that("It runs one individual simulation without simulationRunOptions", {
@@ -197,14 +197,14 @@ test_that("It throws an error when running multiple simulations with a populatio
   sim2 <- loadTestSimulation("simple", loadFromCache = FALSE)
   populationFileName <- getTestDataFilePath(fileName = "pop.csv")
   population <- loadPopulation(csvPopulationFile = populationFileName)
-  expect_that(runSimulations(simulations = c(sim1, sim2), population = population), throws_error())
+  expect_error(runSimulations(simulations = c(sim1, sim2), population = population))
 })
 
 test_that("It throws an error when running the same instance of a simulation multiple time", {
   resetSimulationCache()
   sim1 <- loadTestSimulation("simple", loadFromCache = TRUE)
   sim2 <- loadTestSimulation("simple", loadFromCache = TRUE)
-  expect_that(runSimulations(simulations = c(sim1, sim2)), throws_error())
+  expect_error(runSimulations(simulations = c(sim1, sim2)))
 })
 
 context("getStandardMoleculeParameters")
@@ -231,7 +231,7 @@ test_that("It returns all parameter potentially interesting for sensitivity anal
 context("createSimulationBatch")
 test_that("It throws an error when initializing a simulation batch without any variable parameter or molecule", {
   sim <- loadTestSimulation("simple", loadFromCache = TRUE)
-  expect_that(createSimulationBatch(simulation = sim), throws_error())
+  expect_error(createSimulationBatch(simulation = sim))
 })
 
 test_that("It creates a simulation batch when using only parameter paths", {

--- a/tests/testthat/test-utilities-units.R
+++ b/tests/testthat/test-utilities-units.R
@@ -48,7 +48,7 @@ test_that("It can convert from an array of values in base unit to a target unit"
 })
 
 test_that("It throws an exception when converting to a unit that is not suppored", {
-  expect_that(toUnit(par, 1000, "kg"), throws_error())
+  expect_error(toUnit(par, 1000, "kg"))
 })
 
 test_that("It does not change the value of the quantity when converting to another unit", {
@@ -93,7 +93,7 @@ test_that("It can convert from an array of values in a unit to base unit", {
 })
 
 test_that("It throws an exception when converting to a unit that is not suppored", {
-  expect_that(toBaseUnit(par, 1000, "kg"), throws_error())
+  expect_error(toBaseUnit(par, 1000, "kg"))
 })
 
 test_that("It can convert NULL in unit to NULL", {
@@ -153,7 +153,7 @@ test_that("It can return the expected set of units for a given dimension", {
 })
 
 test_that("It throws an error if the dimension is not found", {
-  expect_that(getUnitsForDimension("toto"), throws_error())
+  expect_error(getUnitsForDimension("toto"))
 })
 
 context("hasDimension")

--- a/tests/testthat/test-utility-pk-parameter.R
+++ b/tests/testthat/test-utility-pk-parameter.R
@@ -68,5 +68,5 @@ test_that("It should return null When returning a pk parameter by name that does
 })
 
 test_that("It should throw an exception When returning a pk parameter by name that does not exist and an exception should be thrown", {
-  expect_that(pkParameterByName("MyTmax", stopIfNotFound = TRUE), throws_error())
+  expect_error(pkParameterByName("MyTmax", stopIfNotFound = TRUE))
 })


### PR DESCRIPTION
A single line of code does the trick!

```r
xfun::gsub_dir(
  "(expect_that\\()(.*)(, throws_error\\(\\))",
  "\\expect_error(\\2",
  ext = "R",
  dir = "tests/"
)
```