### PR TITLE
exclude zzz from code coverage computation

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,8 @@
+# nocov start
 .onLoad <- function(...) {
 
-  # Only for x64 bits packages. This is required to avoid error when package is being checked on CI for x86
+  # Only for x64 bits packages.
+  # This is required to avoid error when package is being checked on CI for x86
   is64 <- (.Machine$sizeof.pointer == 8)
   if (!is64) {
     return()
@@ -8,3 +10,4 @@
 
   initPackage()
 }
+# nocov end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ before_test:
   - pandoc -v
 
 on_success:
-  - Rscript -e "covr::codecov(function_exclusions = c('print.*', '\\.onLoad'))"
+  - Rscript -e "covr::codecov(function_exclusions = c('print.*'))"
 
 test_script:
   - travis-tool.sh run_tests


### PR DESCRIPTION
Using these tags would work with all CI, and not just with AppVeyor, and it's future-proof. 
Plus, the tags are next to the actual code which can't be tested, and this is much more informative for someone wondering where are tests for this code.

Alternative to this:

https://github.com/Open-Systems-Pharmacology/OSPSuite-R/blob/c31ecc2bc2b7668de0dc4d00d6beb0f579699d06/appveyor.yml#L54-L55

I am not sure why we are excluding print functions from code coverage. They can be easily tested using snapshots.
cf. https://github.com/Open-Systems-Pharmacology/OSPSuite.RUtils/blob/develop/tests/testthat/test-Printable.R