### PR TITLE
complete rewrite of `.unitConverter()` using base-R

### DIFF
--- a/R/unitConverter.R
+++ b/R/unitConverter.R
@@ -55,10 +55,17 @@
   xDataList <- split(data, data$xUnit)
   data <- dplyr::bind_rows(lapply(xDataList, .xUnitConverter, xTargetUnit))
 
-  # yUnit and error ----------------
+  # yUnit ----------------
 
   yDataList <- split(data, data$yUnit)
   data <- dplyr::bind_rows(lapply(yDataList, .yUnitConverter, yTargetUnit))
+
+  # yUnit error ----------------
+
+  if ("yErrorValues" %in% names(data)) {
+    yErrorDataList <- split(data, data$yErrorUnit)
+    data <- dplyr::bind_rows(lapply(yErrorDataList, .yErrorUnitConverter, yTargetUnit))
+  }
 
   data
 }
@@ -92,16 +99,22 @@
 
   yData$yUnit <- yTargetUnit
 
-  if ("yErrorValues" %in% names(yData)) {
-    yData$yErrorValues <- toUnit(
-      quantityOrDimension = yData$yDimension[[1]],
-      values = yData$yErrorValues,
-      targetUnit = yData$yUnit[[1]],
-      sourceUnit = yData$yErrorUnit[[1]],
-      molWeight = yData$molWeight[[1]],
-      molWeightUnit = ospUnits$`Molecular weight`$`g/mol`
-    )
-  }
+  yData
+}
+
+#' @keywords internal
+#' @noRd
+.yErrorUnitConverter <- function(yData, yTargetUnit) {
+  yData$yErrorValues <- toUnit(
+    quantityOrDimension = yData$yDimension[[1]],
+    values = yData$yErrorValues,
+    targetUnit = yTargetUnit,
+    sourceUnit = yData$yErrorUnit[[1]],
+    molWeight = yData$molWeight[[1]],
+    molWeightUnit = ospUnits$`Molecular weight`$`g/mol`
+  )
+
+  yData$yErrorUnit <- yTargetUnit
 
   yData
 }

--- a/R/unitConverter.R
+++ b/R/unitConverter.R
@@ -57,17 +57,17 @@
 
   # yUnit ----------------
 
-  yDataList <- split(data, data$yUnit)
+  yDataList <- split(data, yUnit ~ molWeight)
   data <- dplyr::bind_rows(lapply(yDataList, .yUnitConverter, yTargetUnit))
 
   # yUnit error ----------------
 
   if ("yErrorValues" %in% names(data)) {
-    yErrorDataList <- split(data, data$yErrorUnit)
+    yErrorDataList <- split(data, yErrorUnit ~ molWeight)
     data <- dplyr::bind_rows(lapply(yErrorDataList, .yErrorUnitConverter, yTargetUnit))
   }
 
-  data
+  return(data)
 }
 
 #' @keywords internal
@@ -82,7 +82,7 @@
 
   xData$xUnit <- xTargetUnit
 
-  xData
+  return(xData)
 }
 
 #' @keywords internal
@@ -99,7 +99,7 @@
 
   yData$yUnit <- yTargetUnit
 
-  yData
+  return(yData)
 }
 
 #' @keywords internal
@@ -116,5 +116,5 @@
 
   yData$yErrorUnit <- yTargetUnit
 
-  yData
+  return(yData)
 }

--- a/R/unitConverter.R
+++ b/R/unitConverter.R
@@ -57,13 +57,13 @@
 
   # yUnit ----------------
 
-  yDataList <- split(data, yUnit ~ molWeight)
+  yDataList <- split(data, list(data$yUnit, data$molWeight))
   data <- dplyr::bind_rows(lapply(yDataList, .yUnitConverter, yTargetUnit))
 
   # yUnit error ----------------
 
   if ("yErrorValues" %in% names(data)) {
-    yErrorDataList <- split(data, yErrorUnit ~ molWeight)
+    yErrorDataList <- split(data, list(data$yErrorUnit, data$molWeight))
     data <- dplyr::bind_rows(lapply(yErrorDataList, .yErrorUnitConverter, yTargetUnit))
   }
 

--- a/tests/testthat/test-unitConverter.R
+++ b/tests/testthat/test-unitConverter.R
@@ -122,3 +122,16 @@ test_that(".unitConverter doesn't change dimensions under any circumstances", {
 
   expect_equal(dim(dfMWConvert), dim(dfMW))
 })
+
+# Same yUnit but different mw
+
+test_that("Correct conversion for yValues having the same unit but different MW", {
+  df <- dplyr::tibble(
+    xValues = c(15, 30, 60), xUnit = "min", xDimension = "Time",
+    yValues = c(1, 1, 1), yUnit = c("mol", "mol", "mol"), yDimension = c(ospDimensions$Amount, ospDimensions$Amount, ospDimensions$Amount),
+    molWeight = c(10, 10, 20)
+  )
+  dfConvert <- .unitConverter(df, yUnit = "g")
+
+  expect_equal(dfConvert$yValues, c(10, 10, 20))
+})

--- a/tests/testthat/test-unitConverter.R
+++ b/tests/testthat/test-unitConverter.R
@@ -9,6 +9,14 @@ df <- dplyr::tibble(
   molWeight = c(10, 10, 10)
 )
 
+# also contains error columns
+dfError <- dplyr::tibble(
+  xValues = c(15, 30, 60), xUnit = "min", xDimension = "Time",
+  yValues = c(0.25, 45, 78), yUnit = c("", "%", "%"), yDimension = c("Fraction", "Fraction", "Fraction"),
+  yErrorValues = c(0.01, 5, 8), yErrorUnit = c("", "%", "%"),
+  molWeight = c(10, 10, 10)
+)
+
 # default conversion -------------------
 
 dfConvert <- .unitConverter(df)
@@ -121,6 +129,23 @@ test_that(".unitConverter doesn't change dimensions under any circumstances", {
   expect_equal(dim(dfXYConvert), dim(df))
 
   expect_equal(dim(dfMWConvert), dim(dfMW))
+})
+
+# error units -------------------
+
+dfErrorConvert <- .unitConverter(dfError)
+dfYErrorConvert <- .unitConverter(dfError, yUnit = ospUnits$Fraction$`%`)
+
+test_that(".unitConverter changes error units as well - defaults", {
+  expect_equal(unique(dfErrorConvert$yErrorUnit), "")
+  expect_equal(dfErrorConvert$yErrorValues[1], dfError$yErrorValues[1])
+  expect_equal(dfErrorConvert$yErrorValues[2:3] * 100, dfError$yErrorValues[2:3])
+})
+
+test_that(".unitConverter changes error units as well - defaults", {
+  expect_equal(unique(dfYErrorConvert$yErrorUnit), "%")
+  expect_equal(dfYErrorConvert$yErrorValues[1] / 100, dfError$yErrorValues[1])
+  expect_equal(dfYErrorConvert$yErrorValues[2:3], dfError$yErrorValues[2:3])
 })
 
 # Same yUnit but different mw

--- a/tests/testthat/test-unitConverter.R
+++ b/tests/testthat/test-unitConverter.R
@@ -148,7 +148,7 @@ test_that(".unitConverter changes error units as well - defaults", {
   expect_equal(dfYErrorConvert$yErrorValues[2:3], dfError$yErrorValues[2:3])
 })
 
-# Same yUnit but different mw
+# different molecular weights handled properly -------------------
 
 test_that("Correct conversion for yValues having the same unit but different MW", {
   df <- dplyr::tibble(


### PR DESCRIPTION
``` r
library(ospsuite)
#> Loading required package: rClr
#> Loading the dynamic library for Microsoft .NET runtime...
#> Loaded Common Language Runtime version 4.0.30319.42000

df <- dplyr::tibble(
  xValues = c(15, 30, 60), xUnit = "min", xDimension = "Time",
  yValues = c(0.25, 45, 78), yUnit = c("", "%", "%"), yDimension = c("Fraction", "Fraction", "Fraction"),
  molWeight = c(10, 10, 10)
)

ospsuite:::.unitConverter(df)
#> [1] "ping for  min"
#> [1] "ping for  "
#> [1] "ping for  %"
#> # A tibble: 3 x 7
#>   xValues xUnit xDimension yValues yUnit yDimension molWeight
#>     <dbl> <chr> <chr>        <dbl> <chr> <chr>          <dbl>
#> 1      15 min   Time          0.25 ""    Fraction          10
#> 2      30 min   Time          0.45 ""    Fraction          10
#> 3      60 min   Time          0.78 ""    Fraction          10
```

<sup>Created on 2022-04-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>
