### PR TITLE
Anticipate presence of multiple dimensions while preparing axes labels

### DIFF
--- a/R/utilities-plotting.R
+++ b/R/utilities-plotting.R
@@ -194,8 +194,10 @@
   # axes labels.
   xUnitString <- unique(data$xUnit)
   yUnitString <- unique(data$yUnit)
-  xDimensionString <- unique(data$xDimension)
-  yDimensionString <- unique(data$yDimension)
+
+  # There might be multiple dimensions across datasets, select the first one.
+  xDimensionString <- unique(data$xDimension)[[1]]
+  yDimensionString <- unique(data$yDimension)[[1]]
 
   # Currently, hard code any of the different concentration dimensions to just
   # one dimension: "Concentration"

--- a/R/utilities-plotting.R
+++ b/R/utilities-plotting.R
@@ -208,11 +208,11 @@
     ospDimensions$`Concentration (molar)`
   )
 
-  if (xDimensionString %in% concDimensions) {
+  if (any(xDimensionString %in% concDimensions)) {
     xDimensionString <- "Concentration"
   }
 
-  if (yDimensionString %in% concDimensions) {
+  if (any(yDimensionString %in% concDimensions)) {
     yDimensionString <- "Concentration"
   }
 

--- a/tests/testthat/test-plot-individual-time-profile.R
+++ b/tests/testthat/test-plot-individual-time-profile.R
@@ -111,31 +111,3 @@ test_that("It creates default plots as expected for only simulated", {
   )
 })
 
-context(".createAxesLabels")
-
-df <- dplyr::tibble(
-  dataType = c(rep("simulated", 3), rep("observed", 3)),
-  xValues = c(0, 14.482, 28.965, 0, 1, 2),
-  xUnit = "min",
-  xDimension = "Time",
-  yValues = c(1, 1, 1, 1, 1, 1),
-  yUnit = "mol/ml",
-  yDimension = ospDimensions$`Concentration (mass)`,
-  yErrorValues = c(2.747, 2.918, 2.746, NA, NA, NA),
-  molWeight = c(10, 10, 20, 20, 10, 10)
-)
-
-test_that("It returns NULL when arguments are missing", {
-  expect_null(.createAxesLabels(df))
-})
-
-test_that("It returns NULL when data frame is empty", {
-  expect_null(.createAxesLabels(data.frame(), TimeProfilePlotConfiguration$new()))
-})
-
-test_that("It replaces 'Concentration (molar)' and 'Concentration (mass)' by 'Concentration' in plot axis labels", {
-  labels <- .createAxesLabels(.unitConverter(df), TimeProfilePlotConfiguration$new())
-
-  expect_equal(labels$xLabel, "Time [min]")
-  expect_equal(labels$yLabel, "Concentration [mol/ml]")
-})

--- a/tests/testthat/test-utilities-plotting.R
+++ b/tests/testthat/test-utilities-plotting.R
@@ -1,0 +1,51 @@
+context(".createAxesLabels")
+
+df <- dplyr::tibble(
+  dataType = c(rep("simulated", 3), rep("observed", 3)),
+  xValues = c(0, 14.482, 28.965, 0, 1, 2),
+  xUnit = "min",
+  xDimension = "Time",
+  yValues = c(1, 1, 1, 1, 1, 1),
+  yUnit = "mol/ml",
+  yDimension = ospDimensions$`Concentration (mass)`,
+  yErrorValues = c(2.747, 2.918, 2.746, NA, NA, NA),
+  molWeight = c(10, 10, 20, 20, 10, 10)
+)
+
+test_that("It returns NULL when arguments are missing", {
+  expect_null(.createAxesLabels(df))
+})
+
+test_that("It returns NULL when data frame is empty", {
+  expect_null(.createAxesLabels(data.frame(), TimeProfilePlotConfiguration$new()))
+})
+
+test_that("It replaces 'Concentration (molar)' and 'Concentration (mass)' by 'Concentration' in plot axis labels", {
+  labels <- .createAxesLabels(.unitConverter(df), TimeProfilePlotConfiguration$new())
+
+  expect_equal(labels$xLabel, "Time [min]")
+  expect_equal(labels$yLabel, "Concentration [mol/ml]")
+})
+
+
+test_that("It works correctly when multiple dimensions are present", {
+  concDataSet <- DataSet$new(name = "Concentration data set")
+  concDataSet$setValues(1, 1)
+  concDataSet$yDimension <- ospDimensions$`Concentration (molar)`
+  concDataSet$molWeight <- 1
+
+  amountDataSet <- DataSet$new(name = "Amount data set")
+  amountDataSet$setValues(1, 1)
+  amountDataSet$yDimension <- ospDimensions$`Concentration (mass)`
+  amountDataSet$molWeight <- 1
+
+  myCombDat <- DataCombined$new()
+  myCombDat$addDataSets(c(concDataSet, amountDataSet))
+
+  df <- myCombDat$toDataFrame()
+
+  labs <- .createAxesLabels(.unitConverter(df), tlf::TimeProfilePlotConfiguration$new())
+
+  expect_equal(labs$xLabel, "Time [h]")
+  expect_equal(labs$yLabel, "Concentration [µmol/l]")
+})

--- a/tests/testthat/test-utilities-plotting.R
+++ b/tests/testthat/test-utilities-plotting.R
@@ -47,5 +47,5 @@ test_that("It works correctly when multiple dimensions are present", {
   labs <- .createAxesLabels(.unitConverter(df), tlf::TimeProfilePlotConfiguration$new())
 
   expect_equal(labs$xLabel, "Time [h]")
-  expect_equal(labs$yLabel, "Concentration [µmol/l]")
+  expect_equal(labs$yLabel, "Concentration [mg/l]")
 })


### PR DESCRIPTION
Closes #967

``` r
library(ospsuite)
#> Loading required package: rClr
#> Loading the dynamic library for Microsoft .NET runtime...
#> Loaded Common Language Runtime version 4.0.30319.42000

concDataSet <- DataSet$new(name = "Concentration data set")
concDataSet$setValues(1, 1)
concDataSet$yDimension <- ospDimensions$`Concentration (molar)`
concDataSet$molWeight <- 1

amountDataSet <- DataSet$new(name = "Amount data set")
amountDataSet$setValues(1, 1)
amountDataSet$yDimension <- ospDimensions$`Concentration (mass)`
amountDataSet$molWeight <- 1

myCombDat <- DataCombined$new()
myCombDat$addDataSets(c(concDataSet, amountDataSet))

plotConfiguration <- ospsuite::DefaultPlotConfiguration$new()
plotIndividualTimeProfile(myCombDat, plotConfiguration)
#> Warning: Removed 2 rows containing missing values (geom_segment).
#> Removed 2 rows containing missing values (geom_segment).
```

![](https://i.imgur.com/VwODp5X.png)

<sup>Created on 2022-05-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>
