### PR TITLE
Fixes #986 Nightly build failing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ospsuite
 Title: R package to manipulate OSPSuite Models
-Version: 11.1.0.9000
+Version: 11.1.0
 Authors@R: 
     c(person("Open-Systems-Pharmacology Community", role = "cph"),
       person("Michael", "Sevestre", role = c("aut", "cre"), email = "michael@design2code.ca"),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,7 +4,7 @@ template:
   bootstrap: 5
 
 development:
-  mode: auto
+  mode: devel
 
 authors:
   Indrajeet Patil:


### PR DESCRIPTION
Nightly fails now because the Linux patching tries to update **ospsuite_11.1.N.tar.gz** - but the package created is **ospsuite_11.1.N.9000.tar.gz**

So I removed this .9000 from the DESCRIPTION and instead set `mode: devel` in **_pkgdown.yml**
With this, the website will be generated under **docs/dev** until the mode is changed to `mode: release` (which must be done once before release).

Probably a better solution anyway and we should do this for all other packages as well?