### PR TITLE
Don't lock environment for `DefaultPlotConfiguration` class

### DIFF
--- a/R/default-plot-configuration.R
+++ b/R/default-plot-configuration.R
@@ -162,6 +162,8 @@
 #' @export
 DefaultPlotConfiguration <- R6::R6Class(
   "DefaultPlotConfiguration",
+  lock_objects = FALSE,
+  lock_class = FALSE,
   public = list(
     # units ------------------------------------
     xUnit = NULL,


### PR DESCRIPTION
Otherwise, if we try to extend this class further (like [here](https://esqlabs.github.io/esqlabsR/reference/createEsqlabsPlotConfiguration.html)), we get the following error:

> "cannot add bindings to a locked environment"

`[L]` signifies that the environment is locked.

``` r
library(R6)

Person1 <- R6Class("Person")
rlang::env_print(Person1$new())
#> <environment: 0x000000001967f5b8> [L]
#> Parent: <environment: empty>
#> Class: Person, R6
#> Bindings:
#> * .__enclos_env__: <env>
#> * clone: <fn> [L]

Person2 <- R6Class("Person", lock_objects = FALSE)
rlang::env_print(Person2$new())
#> <environment: 0x000000002026b370>
#> Parent: <environment: empty>
#> Class: Person, R6
#> Bindings:
#> * .__enclos_env__: <env>
#> * clone: <fn> [L]
```

<sup>Created on 2022-07-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>
