### PR TITLE
Pass lloq to residuals data frame

### DIFF
--- a/R/utilities-data-combined.R
+++ b/R/utilities-data-combined.R
@@ -203,7 +203,9 @@ calculateResiduals <- function(dataCombined,
     # Everything related to the X-variable
     "xValues", "xUnit", "xDimension", dplyr::matches("^x"),
     # Everything related to the Y-variable
-    "yValuesObserved" = "yValues", "yUnit", "yDimension", dplyr::matches("^y")
+    "yValuesObserved" = "yValues", "yUnit", "yDimension", dplyr::matches("^y"),
+	# lower limit of quantification
+	"lloq"
   )
 
   # Add predicted values

--- a/tests/testthat/test-utilities-data-combined.R
+++ b/tests/testthat/test-utilities-data-combined.R
@@ -17,6 +17,7 @@ obsData <- DataSet$new(name = "Observed")
 obsData$setValues(xValues = c(0, 1, 3, 3.5, 4, 5, 6), yValues = c(0, 1.9, 6.1, 7, 8.2, 1, 0))
 obsData$xUnit <- "min"
 obsData$yDimension <- ospDimensions$`Concentration (molar)`
+obsData$LLOQ <- 0.02
 myDC <- DataCombined$new()
 myDC$addSimulationResults(simData, groups = "myGroup")
 myDC$addDataSets(obsData, groups = "myGroup")
@@ -46,6 +47,22 @@ test_that(
   "calculateResiduals returns expected columns",
   expect_setequal(
     expected_column_names, colnames(calculateResiduals(myDC, scaling = "lin"))
+  )
+)
+
+test_that(
+  "DataCombined objects keep LLOQ data passed from underlying DataSet objects", 
+  expect_equal(
+    myDC$toDataFrame()$lloq, 
+	c(rep(0.02, length(obsData$yValues)), rep(NA, nrow(df)))
+  )
+)
+
+test_that(
+  "calculateResiduals function keeps passes lloq data through", 
+  expect_equal(
+    calculateResiduals(myDC, scaling = "lin")$lloq,
+	rep(0.02, 6)
   )
 )
 

--- a/tests/testthat/test-utilities-data-combined.R
+++ b/tests/testthat/test-utilities-data-combined.R
@@ -41,7 +41,7 @@ test_that(
     "data.frame" %in% class(calculateResiduals(myDC, scaling = "lin"))
   )
 )
-expected_column_names <- c("group", "name", "xValues", "xUnit", "xDimension", "yValuesObserved", "yUnit", "yDimension", "yErrorValues", "yErrorType", "yErrorUnit", "yValuesSimulated", "residualValues")
+expected_column_names <- c("group", "name", "xValues", "xUnit", "xDimension", "yValuesObserved", "yUnit", "yDimension", "yErrorValues", "yErrorType", "yErrorUnit", "lloq", "yValuesSimulated", "residualValues")
 test_that(
   "calculateResiduals returns expected columns",
   expect_setequal(


### PR DESCRIPTION
Adds `lloq` column to outputs of the `calculateResiduals()` function. I need these data to write objective functions for parameter identification that involve LLOQ values.