### PR TITLE
Improve performance of toUnit by exiting early

### DIFF
--- a/R/aging-data.R
+++ b/R/aging-data.R
@@ -1,4 +1,3 @@
-
 #' @title AgingData
 #' @docType class
 #' @description  Results of a sensitivity analysis run (either individual or population simulation)

--- a/R/object-base.R
+++ b/R/object-base.R
@@ -1,4 +1,3 @@
-
 #' @title ObjectBase
 #' @docType class
 #' @description  Abstract wrapper for an OSPSuite.Core ObjectBase.

--- a/R/pk-parameter-sensitivity.R
+++ b/R/pk-parameter-sensitivity.R
@@ -1,4 +1,3 @@
-
 #' @title PKParameterSensitivity
 #' @docType class
 #' @description  Sensitivity of a PK Parameter for one output for a given parameter

--- a/R/pk-sim.R
+++ b/R/pk-sim.R
@@ -1,4 +1,3 @@
-
 #' Default species defined in PK-Sim
 #'
 #'

--- a/R/quantity-pk-parameter.R
+++ b/R/quantity-pk-parameter.R
@@ -1,4 +1,3 @@
-
 #' @title QuantityPKParameter
 #' @docType class
 #' @description  pK-Parameter values for all individuals of a simulation (1 or more) calculated for a specific quantity with path `quantityPath`

--- a/R/simulation-pk-analyses.R
+++ b/R/simulation-pk-analyses.R
@@ -1,4 +1,3 @@
-
 #' @title SimulationPKAnalyses
 #' @docType class
 #' @description  pK-Analyses of a simulation (either individual or population simulation).

--- a/R/standard-path.R
+++ b/R/standard-path.R
@@ -1,4 +1,3 @@
-
 #' Standard containers typically available in a PBPK simulation
 #'
 #'

--- a/R/utilities-container.R
+++ b/R/utilities-container.R
@@ -1,4 +1,3 @@
-
 #' Retrieve all sub containers of a parent container (simulation or container instance) matching the given path criteria
 #'
 #' @param paths A vector of strings representing the paths relative to the `container`

--- a/R/utilities-data-combined.R
+++ b/R/utilities-data-combined.R
@@ -204,8 +204,8 @@ calculateResiduals <- function(dataCombined,
     "xValues", "xUnit", "xDimension", dplyr::matches("^x"),
     # Everything related to the Y-variable
     "yValuesObserved" = "yValues", "yUnit", "yDimension", dplyr::matches("^y"),
-	# lower limit of quantification
-	"lloq"
+    # lower limit of quantification
+    "lloq"
   )
 
   # Add predicted values
@@ -249,7 +249,7 @@ calculateResiduals <- function(dataCombined,
 #' @keywords internal
 #' @noRd
 .log_safe <- function(x, base = 10, epsilon = ospsuiteEnv$LOG_SAFE_EPSILON) {
-  x <- sapply(X = x, function(element){
+  x <- sapply(X = x, function(element) {
     element <- ospsuite.utils::toMissingOfType(element, type = "double")
     if (is.na(element)) {
       return(NA_real_)

--- a/R/utilities-dot-net.R
+++ b/R/utilities-dot-net.R
@@ -1,4 +1,3 @@
-
 #' Returns a list containing all properties `propertyName` from the .NET objects `netObjects`
 #'
 #' @param netObjects List of .NET object

--- a/R/utilities-molecule.R
+++ b/R/utilities-molecule.R
@@ -1,5 +1,3 @@
-
-
 #' Retrieve all molecules of a container (simulation or container instance) matching the given path criteria
 #'
 #' @param paths A vector of strings representing the paths relative to the `container`

--- a/R/utilities-parameter-value.R
+++ b/R/utilities-parameter-value.R
@@ -1,4 +1,3 @@
-
 #' Converts a list of .NET `ParameterValue` into a list with 2 entries: `paths`, `values`.
 #' A 3rd optional entry `units` will be defined if the parameter `addUnits` is set to `TRUE`.
 #' Note: Units are only available for .NET object of type `ParameterValueWithUnit`

--- a/R/utilities-parameter.R
+++ b/R/utilities-parameter.R
@@ -1,4 +1,3 @@
-
 #' Retrieve all parameters of a container (simulation or container instance) matching the given path criteria
 #'
 #' @param paths A vector of strings representing the paths relative to the `container`

--- a/R/utilities-pksim.R
+++ b/R/utilities-pksim.R
@@ -1,4 +1,3 @@
-
 #' Loads the `PKSim.R` that will enable create individual and create population workflows.
 #' @param pksimFolderPath Path where PK-Sim is installed. If this is not specified, path will be read from registry using the package version
 #'

--- a/R/utilities-quantity.R
+++ b/R/utilities-quantity.R
@@ -1,4 +1,3 @@
-
 #' Retrieve all quantities of a container (simulation or container instance)
 #' matching the given path criteria
 #'

--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -95,38 +95,22 @@ getBaseUnit <- function(dimension) {
 #' @export
 toBaseUnit <- function(quantityOrDimension, values, unit, molWeight = NULL, molWeightUnit = NULL) {
   validateIsOfType(quantityOrDimension, c("Quantity", "character"))
-  validateIsNumeric(values, nullAllowed = TRUE)
-  validateIsNumeric(molWeight, nullAllowed = TRUE)
-  unit <- .encodeUnit(unit)
+
+  # Get the base unit of the dimension and call `toUnit()`
   dimension <- quantityOrDimension
-  dimensionTask <- .getNetTask("DimensionTask")
-
-  # covers all NULL or NA
-  if (all(is.na(values))) {
-    return(values)
-  }
-
-  # ensure that we are dealing with an list of values seen as number (and not integer)
-  values <- as.numeric(c(values))
-
   if (isOfType(quantityOrDimension, "Quantity")) {
     dimension <- quantityOrDimension$dimension
   }
+  baseUnit <- getBaseUnit(dimension)
 
-  if (all(is.na(molWeight))) {
-    molWeight <- NULL
-  }
-
-
-  if (is.null(molWeight)) {
-    return(rClr::clrCall(dimensionTask, "ConvertToBaseUnit", dimension, unit, values))
-  }
-
-  # Convert molWeight value to base unit if a unit is provided
-  if (!is.null(molWeightUnit)) {
-    molWeight <- rClr::clrCall(dimensionTask, "ConvertToBaseUnit", ospDimensions$`Molecular weight`, molWeightUnit, molWeight)
-  }
-  rClr::clrCall(dimensionTask, "ConvertToBaseUnit", dimension, unit, values, molWeight)
+  toUnit(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = baseUnit,
+    sourceUnit = unit,
+    molWeight = molWeight,
+    molWeightUnit = molWeightUnit
+  )
 }
 
 #' Converts a value given in base unit of a quantity into a target unit
@@ -163,41 +147,58 @@ toUnit <- function(quantityOrDimension,
   validateIsOfType(quantityOrDimension, c("Quantity", "character"))
   validateIsNumeric(values, nullAllowed = TRUE)
   validateIsNumeric(molWeight, nullAllowed = TRUE)
-  targetUnit <- .encodeUnit(targetUnit)
-  dimension <- quantityOrDimension
-  dimensionTask <- .getNetTask("DimensionTask")
-
 
   # covers all NULL or NA
   if (all(is.na(values))) {
     return(values)
   }
 
+  targetUnit <- .encodeUnit(targetUnit)
+
   if (!is.null(sourceUnit)) {
     sourceUnit <- .encodeUnit(sourceUnit)
+
+    # If source and target units are equal, return early
+    if (sourceUnit == targetUnit) {
+      return(values)
+    }
   }
 
+  dimension <- quantityOrDimension
   if (isOfType(quantityOrDimension, "Quantity")) {
     dimension <- quantityOrDimension$dimension
+  }
+  baseUnit <- getBaseUnit(dimension)
+
+  # Return early
+  # If no source unit is defined and target is the base unit
+  if (is.null(sourceUnit) && targetUnit == baseUnit) {
+    return(values)
   }
 
   if (all(is.na(molWeight))) {
     molWeight <- NULL
   }
 
+  dimensionTask <- .getNetTask("DimensionTask")
   # ensure that we are dealing with an list of values seen as number (and not integer)
   values <- as.numeric(c(values))
 
-
+  # Case - no molecular weight is provided
   if (is.null(molWeight)) {
     # Convert values to base unit first if the source unit is provided
     if (!is.null(sourceUnit)) {
       values <- rClr::clrCall(dimensionTask, "ConvertToBaseUnit", dimension, sourceUnit, values)
     }
+    # Return early if target unit is the base unit
+    if (targetUnit == baseUnit) {
+      return(values)
+    }
 
     return(rClr::clrCall(dimensionTask, "ConvertToUnit", dimension, targetUnit, values))
   }
 
+  # Case - molecular weight is provided
   # Convert molWeight value to base unit if a unit is provided
   if (!is.null(molWeightUnit)) {
     molWeight <- rClr::clrCall(dimensionTask, "ConvertToBaseUnit", ospDimensions$`Molecular weight`, molWeightUnit, molWeight)
@@ -206,6 +207,10 @@ toUnit <- function(quantityOrDimension,
   # Convert values to base unit first if the source unit is provided
   if (!is.null(sourceUnit)) {
     values <- rClr::clrCall(dimensionTask, "ConvertToBaseUnit", dimension, sourceUnit, values, molWeight)
+  }
+  # Return early if target unit is the base unit
+  if (targetUnit == baseUnit) {
+    return(values)
   }
 
   rClr::clrCall(dimensionTask, "ConvertToUnit", dimension, targetUnit, values, molWeight)

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -23,6 +23,6 @@ below to see their documentation.
 \describe{
   \item{ospsuite.utils}{\code{\link[ospsuite.utils:op-null-default]{\%||\%}}, \code{\link[ospsuite.utils]{enum}}, \code{\link[ospsuite.utils]{enumGetKey}}, \code{\link[ospsuite.utils]{enumGetValue}}, \code{\link[ospsuite.utils]{enumHasKey}}, \code{\link[ospsuite.utils]{enumKeys}}, \code{\link[ospsuite.utils]{enumPut}}, \code{\link[ospsuite.utils]{enumRemove}}, \code{\link[ospsuite.utils]{enumValues}}}
 
-  \item{tlf}{\code{\link[tlf]{plotGrid}}, \code{\link[tlf]{PlotGridConfiguration}}}
+  \item{tlf}{\code{\link[tlf]{PlotGridConfiguration}}, \code{\link[tlf]{plotGrid}}}
 }}
 

--- a/tests/data/create_and_save_data_combined_objects.R
+++ b/tests/data/create_and_save_data_combined_objects.R
@@ -1,4 +1,3 @@
-
 library(ospsuite)
 
 # path relative to the project directory where data should be saved

--- a/tests/dev/script-benchmark-unitConversion.R
+++ b/tests/dev/script-benchmark-unitConversion.R
@@ -1,0 +1,153 @@
+benchmarkFunction <- function(quantityOrDimension, values, targetUnit, sourceUnit = NULL,
+                              nrIterations = 1000) {
+  for (i in 1:nrIterations) {
+    converted <- toUnit(
+      quantityOrDimension = quantityOrDimension,
+      values = values,
+      targetUnit = targetUnit,
+      sourceUnit = sourceUnit
+    )
+  }
+  return(converted)
+}
+
+quantityOrDimension <- ospDimensions$Time
+
+values <- seq(1, 100000)
+
+#### toUnit####
+# same unit
+sourceUnit <- ospUnits$Time$min
+targetUnit <- ospUnits$Time$min
+
+# Same unit without source specified
+# user  system elapsed
+# 41.18    1.75   74.96
+
+# New version
+# 14.75    1.21   18.73
+system.time(
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    nrIterations = 5000
+  )
+)
+
+# 40k ms
+# 10556 mb
+
+# New version
+# 7k ms
+# 2290 mb
+profvis::profvis({
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    nrIterations = 5000
+  )
+})
+
+# Same unit with source specified
+# user  system elapsed
+# 39.67    0.74  107.83
+
+# New version
+# 15.42    1.35   18.58
+system.time(
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    sourceUnit = sourceUnit,
+    nrIterations = 5000
+  )
+)
+
+# 70k ms
+# 14753mb
+
+# New version
+# 8k ms
+# 2440 mb
+profvis::profvis({
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    sourceUnit = sourceUnit,
+    nrIterations = 5000
+  )
+})
+
+# Diff units with no source specified
+sourceUnit <- ospUnits$Time$s
+targetUnit <- ospUnits$Time$h
+
+# user  system elapsed
+# 35.54    1.00   64.55
+
+# New version
+# 36.15    1.25   67.63
+system.time(
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    nrIterations = 5000
+  )
+)
+
+# 36k ms
+# 10627mb
+
+# New version
+# 33k ms
+# 10326 mb
+profvis::profvis({
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    nrIterations = 5000
+  )
+})
+
+
+#########
+# Diff units with no source specified
+sourceUnit <- ospUnits$Time$s
+targetUnit <- ospUnits$Time$h
+
+# user  system elapsed
+# 58.33    1.63  122.89
+
+# New version
+# 35.24    1.40   90.70
+system.time(
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    sourceUnit = sourceUnit,
+    nrIterations = 5000
+  )
+)
+
+# 70k ms
+# 14680mb
+
+# New version
+# 64k ms
+# 14458 mb
+profvis::profvis({
+  converted <- benchmarkFunction(
+    quantityOrDimension = quantityOrDimension,
+    values = values,
+    targetUnit = targetUnit,
+    sourceUnit = sourceUnit,
+    nrIterations = 5000
+  )
+})

--- a/tests/dev/script-demography.R
+++ b/tests/dev/script-demography.R
@@ -1,4 +1,3 @@
-
 library(ospsuite)
 
 sim <- loadSimulation("tests/data/S1.pkml")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,3 @@
-
 library(testthat)
 library(ospsuite)
 

--- a/tests/testthat/helper-for-tests.R
+++ b/tests/testthat/helper-for-tests.R
@@ -1,4 +1,3 @@
-
 getTestDataFilePath <- function(fileName) {
   dataPath <- file.path(getwd(), "..", "data", fsep = .Platform$file.sep)
   file.path(dataPath, fileName, fsep = .Platform$file.sep)

--- a/tests/testthat/test-molecule.R
+++ b/tests/testthat/test-molecule.R
@@ -1,4 +1,3 @@
-
 context("Molecule in concentration mode")
 
 sim_conc_based <- loadTestSimulation("concentration_based")

--- a/tests/testthat/test-unicode-support.R
+++ b/tests/testthat/test-unicode-support.R
@@ -1,4 +1,3 @@
-
 context("Unicode support")
 
 test_that("It can load a simulation whose name contains unicode characters", {

--- a/tests/testthat/test-utilities-container.R
+++ b/tests/testthat/test-utilities-container.R
@@ -1,4 +1,3 @@
-
 context("getAllContainersMatching")
 
 sim <- loadTestSimulation("S1")

--- a/tests/testthat/test-utilities-data-combined.R
+++ b/tests/testthat/test-utilities-data-combined.R
@@ -51,18 +51,18 @@ test_that(
 )
 
 test_that(
-  "DataCombined objects keep LLOQ data passed from underlying DataSet objects", 
+  "DataCombined objects keep LLOQ data passed from underlying DataSet objects",
   expect_equal(
-    myDC$toDataFrame()$lloq, 
-	c(rep(0.02, length(obsData$yValues)), rep(NA, nrow(df)))
+    myDC$toDataFrame()$lloq,
+    c(rep(0.02, length(obsData$yValues)), rep(NA, nrow(df)))
   )
 )
 
 test_that(
-  "calculateResiduals function keeps passes lloq data through", 
+  "calculateResiduals function keeps passes lloq data through",
   expect_equal(
     calculateResiduals(myDC, scaling = "lin")$lloq,
-	rep(0.02, 6)
+    rep(0.02, 6)
   )
 )
 

--- a/tests/testthat/test-utilities-entity.R
+++ b/tests/testthat/test-utilities-entity.R
@@ -1,4 +1,3 @@
-
 context("uniqueEntities")
 
 sim <- loadTestSimulation("S1")

--- a/tests/testthat/test-utilities-molecule.R
+++ b/tests/testthat/test-utilities-molecule.R
@@ -1,5 +1,3 @@
-
-
 sim <- loadTestSimulation("S1")
 
 context("getAllMoleculesMatching")

--- a/tests/testthat/test-utilities-parameter.R
+++ b/tests/testthat/test-utilities-parameter.R
@@ -1,4 +1,3 @@
-
 context("getAllParametersMatching")
 
 sim <- loadTestSimulation("S1")

--- a/tests/testthat/test-utilities-pk-analysis.R
+++ b/tests/testthat/test-utilities-pk-analysis.R
@@ -1,4 +1,3 @@
-
 context("calculatePKAnalyses")
 
 sim <- loadTestSimulation("S1")

--- a/tests/testthat/test-utilities-pk-parameter.R
+++ b/tests/testthat/test-utilities-pk-parameter.R
@@ -1,4 +1,3 @@
-
 context("addUserDefinedPKParameter")
 
 test_that("It can add a user defined pk-parameter by name and type", {

--- a/vignettes/table-parameters.Rmd
+++ b/vignettes/table-parameters.Rmd
@@ -69,7 +69,6 @@ tableParam$formula$valueAt(90)
 Simply setting the value of a table-defined parameter using `setParameterValues` will override the formula and make the parameter constant.
 
 ```{r setTableToConstant}
-
 # Get the parameter defined by a table.
 tableParam <- getParameter("Organism|TableParameter", sim)
 tableParam


### PR DESCRIPTION
Fixes #1203

Some benchmarks:

```
# Same unit without source specified
# user  system elapsed
# 41.18    1.75   74.96
# New version
# 14.75    1.21   18.73

# Same unit with source specified
# user  system elapsed
# 39.67    0.74  107.83

# New version
# 15.42    1.35   18.58
```

When both units are specified and conversion actually happens, performance is almost the same (even better in some cases, though I don't really know why).