### PR TITLE
Apply mutants replacements only if there is a mu in unit

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -36,8 +36,9 @@
 #' @keywords internal
 .encodeUnit <- function(unit) {
   unit <- enc2utf8(unit)
-  if (stringr::str_detect(unit, "\xc2\xb5|\xce\xbc|\xb5")){
-    unit <- stringr::str_replace_all(unit, "\xc2\xb5|\xce\xbc|\xb5", ospsuiteEnv$muSymbol)
+  mutants <- "\xc2\xb5|\xce\xbc|\xb5"
+  if (stringr::str_detect(unit, pattern = mutants)){
+    unit <- stringr::str_replace_all(unit,  pattern = mutants, replacement = ospsuiteEnv$muSymbol)
   }
   return(unit)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -35,11 +35,10 @@
 #'
 #' @keywords internal
 .encodeUnit <- function(unit) {
-  mu <- ospsuiteEnv$muSymbol
   unit <- enc2utf8(unit)
-  unit <- stringr::str_replace(unit, rawToChar(as.raw(c(0xce, 0xbc))), mu)
-  unit <- stringr::str_replace(unit, rawToChar(as.raw(c(0xc2, 0xb5))), mu)
-  unit <- stringr::str_replace(unit, rawToChar(as.raw(0xb5)), mu)
+  if (stringr::str_detect(unit, "\xc2\xb5|\xce\xbc|\xb5")){
+    unit <- stringr::str_replace_all(unit, "\xc2\xb5|\xce\xbc|\xb5", ospsuiteEnv$muSymbol)
+  }
   return(unit)
 }
 


### PR DESCRIPTION
+ all replacements happen in one stringr call

____

While profiling `dataCombined` tests for performances, I noticed that the `.decodeUnit()` was used very often in the code and took some time compared to other steps.

This is the current function definition:

https://github.com/Open-Systems-Pharmacology/OSPSuite-R/blob/b438bc7dda2da00503c38e368faf9cd9f49b63cd/R/utilities.R#L37-L44

So I propose the following:
```r
.encodeUnit <- function(unit) {
  unit <- enc2utf8(unit)
  if (stringr::str_detect(unit, "\xc2\xb5|\xce\xbc|\xb5")){
    unit <- stringr::str_replace_all(unit, "\xc2\xb5|\xce\xbc|\xb5", ospsuiteEnv$muSymbol)
  }
  return(unit)
}
```
1. It replaces mutants only if one is **detected**.
2. It replaces all mutants in one `stringr` call


## Performance

- It take ~85% less time,
- Used memory reduced  by 70%,
- It generates ~85 % less garbage collection operations

|expression            |    min| median| mem_alloc| n_gc| total_time|
|:---------------------|------:|------:|---------:|----:|----------:|
|new_encodeUnit_detect | 1.17ms| 1.23ms|    49.1KB|   17|      1.23s|
|.encodeUnit           | 9.41ms| 9.67ms|   152.7KB|   73|      9.05s|

![image](https://user-images.githubusercontent.com/34234913/229092741-a67815b4-9cd5-4865-9a32-7384e540c611.png)

## Quality
The function yields the same output at the original one.

```r
all(purrr::map_vec(.x = test_set, .f = new_encodeUnit_detect) == purrr::map_vec(.x = test_set, .f = .encodeUnit))
[1] TRUE
```

## Reproducibility

```r
library(ospsuite)
library(bench)
library(purrr)

no_mu <- "g/L"
mu_1 <- paste0(rawToChar(as.raw(c(0xce, 0xbc))),"g")
mu_2 <- paste0(rawToChar(as.raw(c(0xc2, 0xb5))),"g")
mu_3 <- paste0(rawToChar(as.raw(0xb5)),"g")
unit1 = rawToChar(as.raw(c(0xc2, 0xb5, 0x6d, 0x6f, 0x6c, 0x2f, 0x6c)))
unit2 = rawToChar(as.raw(c(0xce, 0xbc, 0x6d, 0x6f, 0x6c, 0x2f, 0x6c)))
unit3 = rawToChar(as.raw(c(0xb5, 0x6d, 0x6f, 0x6c, 0x2f, 0x6c)))

test_set <- c(rep(no_mu, 63),
              mu_1,
              mu_2,
              mu_3,
              unit1,
              unit2,
              unit3)

.encodeUnit <- function(unit){
  mu <- ospsuite:::ospsuiteEnv$muSymbol
  unit <- enc2utf8(unit)
  unit <- stringr::str_replace(unit, rawToChar(as.raw(c(0xce, 0xbc))), mu)
  unit <- stringr::str_replace(unit, rawToChar(as.raw(c(0xc2, 0xb5))), mu)
  unit <- stringr::str_replace(unit, rawToChar(as.raw(0xb5)), mu)
  return(unit)
}


new_encodeUnit_detect <- function(unit){
  mu <- ospsuite:::ospsuiteEnv$muSymbol
  unit <- enc2utf8(unit)
  if (stringr::str_detect(unit, "\xc2\xb5|\xce\xbc|\xb5")){
    unit <- stringr::str_replace_all(unit, "\xc2\xb5|\xce\xbc|\xb5", mu)
  }
  return(unit)
}


bench_test = sample(rep(test_set, 1000))

results <- 
  bench::mark(
  # one_stringr_call = purrr::map_vec(.x = test_set, .f = new_encodeUnit),
  new_encodeUnit_detect = purrr::map_vec(.x = test_set, .f = new_encodeUnit_detect),
  .encodeUnit = purrr::map_vec(.x = test_set, .f = .encodeUnit),
  iterations = 1000
)

plot(results)

all(purrr::map_vec(.x = test_set, .f = new_encodeUnit_detect) == purrr::map_vec(.x = test_set, .f = .encodeUnit))
```
