### PR TITLE
Improve message when adding data set with same name

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -71,7 +71,7 @@ messages$DataFrameNameAlreadyUsed <- function(DataFrameName){
   warning(paste0("\r\n",
                  "The following name(s) already exist in DataCombined:",
                  "\r\n",
-                 "- ", paste(DataFrameName, collapse = "\r\n  - "),
+                 "  - ", paste(DataFrameName, collapse = "\r\n  - "),
                  "\r\n",
                  "Existing data will be overwriten."))
 }

--- a/R/messages.R
+++ b/R/messages.R
@@ -66,3 +66,12 @@ messages$plotObservedVsSimulatedWrongFoldDistance <- function(parameterName, fol
   paste0("Parameter '", parameterName, "' should be >1! Following values have
          been passed: '", paste(foldDistances, collapse = ", "), "'.")
 }
+
+messages$DataFrameNameAlreadyUsed <- function(DataFrameName){
+  warning(paste0("\r\n",
+                 "The following name(s) already exist in DataCombined:",
+                 "\r\n",
+                 "- ", paste(DataFrameName, collapse = "\r\n  - "),
+                 "\r\n",
+                 "Existing data will be overwriten."))
+}

--- a/R/messages.R
+++ b/R/messages.R
@@ -73,5 +73,5 @@ messages$DataFrameNameAlreadyUsed <- function(DataFrameName){
                  "\r\n",
                  "  - ", paste(DataFrameName, collapse = "\r\n  - "),
                  "\r\n",
-                 "Existing data will be overwriten."))
+                 "Existing data will be overwritten."))
 }

--- a/R/utilities-simulation-results.R
+++ b/R/utilities-simulation-results.R
@@ -12,21 +12,7 @@
 #' Results of a simulation of a single individual is treated as a population
 #' simulation with only one individual.
 #'
-#' @param simulationResults Object of type `SimulationResults` produced by
-#'   calling `runSimulation` on a `Simulation` object.
-#' @param quantitiesOrPaths Quantity instances (element or vector) typically
-#'   retrieved using `getAllQuantitiesMatching` or quantity path (element or
-#'   vector of strings) for which the results are to be returned. (optional)
-#'   When providing the paths, only absolute full paths are supported (i.e., no
-#'   matching with '*' possible). If quantitiesOrPaths is `NULL` (default
-#'   value), returns the results for all output defined in the results.
-#' @param individualIds `numeric` IDs of individuals for which the results
-#'   should be extracted. By default, all individuals from the results are
-#'   considered. If the individual with the provided ID is not found, the ID is
-#'   ignored.
-#' @param population population used to calculate the `simulationResults`
-#'   (optional). This is used only to add the population covariates to the
-#'   resulting data table.
+#' @template simulation_results
 #' @param stopIfNotFound If `TRUE` (default) an error is thrown if no results
 #'   exist for any `path`. If `FALSE`, a list of `NA` values is returned for the
 #'   respective path.

--- a/man-roxygen/simulation_results.R
+++ b/man-roxygen/simulation_results.R
@@ -1,0 +1,15 @@
+#' @param simulationResults Object of type `SimulationResults` produced by
+#'   calling `runSimulation` on a `Simulation` object.
+#' @param quantitiesOrPaths Quantity instances (element or vector) typically
+#'   retrieved using `getAllQuantitiesMatching` or quantity path (element or
+#'   vector of strings) for which the results are to be returned. (optional)
+#'   When providing the paths, only absolute full paths are supported (i.e., no
+#'   matching with '*' possible). If quantitiesOrPaths is `NULL` (default
+#'   value), returns the results for all output defined in the results.
+#' @param population population used to calculate the `simulationResults`
+#'   (optional). This is used only to add the population covariates to the
+#'   resulting data table.
+#' @param individualIds `numeric` IDs of individuals for which the results
+#'   should be extracted. By default, all individuals from the results are
+#'   considered. If the individual with the provided ID is not found, the ID is
+#'   ignored.

--- a/man/DataCombined.Rd
+++ b/man/DataCombined.Rd
@@ -150,25 +150,23 @@ Add simulated data using instance of \code{SimulationResults} class.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{simulationResults}}{Object of type \code{SimulationResults} produced by
-calling \code{runSimulation()} on a \code{Simulation} object. Only a single
-instance is allowed in a given \verb{$addSimulationResults()} method call.}
+calling \code{runSimulation} on a \code{Simulation} object.}
 
-\item{\code{quantitiesOrPaths}}{Quantity instances (element or list) typically
-retrieved using \code{getAllQuantitiesMatching()} or quantity path (element
-or list of strings) for which the results are to be returned.
-(optional) When providing the paths, only absolute full paths are
-supported (i.e., no matching with '*' possible). If \code{quantitiesOrPaths}
-is \code{NULL} (default value), returns the results for all output defined
-in the results.}
+\item{\code{quantitiesOrPaths}}{Quantity instances (element or vector) typically
+retrieved using \code{getAllQuantitiesMatching} or quantity path (element or
+vector of strings) for which the results are to be returned. (optional)
+When providing the paths, only absolute full paths are supported (i.e., no
+matching with '*' possible). If quantitiesOrPaths is \code{NULL} (default
+value), returns the results for all output defined in the results.}
 
-\item{\code{population}}{Population used to calculate the \code{simulationResults}
+\item{\code{population}}{population used to calculate the \code{simulationResults}
 (optional). This is used only to add the population covariates to the
-resulting data frame.}
+resulting data table.}
 
-\item{\code{individualIds}}{Numeric IDs of individuals for which the results
+\item{\code{individualIds}}{\code{numeric} IDs of individuals for which the results
 should be extracted. By default, all individuals from the results are
-considered. If the individual with the provided ID is not found, the ID
-is ignored.}
+considered. If the individual with the provided ID is not found, the ID is
+ignored.}
 
 \item{\code{names}}{A string or a \code{list} of strings assigning new names. These new
 names can be either for renaming \code{DataSet} objects, or for renaming

--- a/man/messages.Rd
+++ b/man/messages.Rd
@@ -6,7 +6,7 @@
 \title{List of functions and strings used to signal error messages
 Extends the \code{messages} list from ospsuite.utils}
 \format{
-An object of class \code{list} of length 50.
+An object of class \code{list} of length 51.
 }
 \usage{
 messages

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -591,7 +591,7 @@ test_that("data order with or without `names` argument should be same", {
   # don't specify names argument for one, while do for the other
   myCombDat$addDataSets(list(dataSet[[1]], dataSet[[2]], dataSet[[3]]))
   myCombDat2$addDataSets(list(dataSet[[1]], dataSet[[2]], dataSet[[3]]),
-    names = list("x", "y", NULL)
+                         names = list("x", "y", NULL)
   )
 
   # extract data frames
@@ -628,6 +628,19 @@ test_that("data frame should be same when objects are entered either as a list o
   myCombDat2$addDataSets(c(dataSet[[1]], dataSet[[2]], dataSet[[3]]))
 
   expect_equal(myCombDat1$toDataFrame(), myCombDat2$toDataFrame())
+})
+
+test_that("it shows a warning when a dataset is added with the same name as a dataset already present in dataCombined",{
+  ds <- DataSet$new(name = "test")
+  ds$setValues(1, 1)
+
+  dc <- DataCombined$new()
+  dc$addDataSets(ds)
+  expect_warning(dc$addDataSets(ds))
+
+  dc$addSimulationResults(simResults)
+  expect_warning(dc$addSimulationResults(simResults))
+
 })
 
 # data transformations --------------------------


### PR DESCRIPTION
This PR implements #1183.

Here are the feedback warnings the user gets when adding a dataSet or simulationResults with a name already used in a dataCombined object.
``` r
devtools::load_all(".")
#> ℹ Loading ospsuite
#> Loading required package: rClr
#> 
#> Loading the dynamic library for Microsoft .NET runtime...
#> Loaded Common Language Runtime version 4.0.30319.42000

sim <- loadTestSimulation("MinimalModel")
simResults <- importResultsFromCSV(
  simulation = sim,
  filePaths = getTestDataFilePath("Stevens_2012_placebo_indiv_results.csv")
)

ds <- DataSet$new(name = "test")
ds$setValues(1, 1)

dc <- DataCombined$new()

dc$addDataSets(ds)
dc$addDataSets(ds)
#> Warning in messages$DataFrameNameAlreadyUsed(intersect(newNames, self$names)): 
#> The following name(s) already exist in DataCombined:
#>   - test
#> Existing data will be overwriten.

dc$addSimulationResults(simResults)
dc$addSimulationResults(simResults)
#> Warning in messages$DataFrameNameAlreadyUsed(intersect(newNames, self$names)): 
#> The following name(s) already exist in DataCombined:
#>   - Organism|Lumen|Stomach|Dapagliflozin|Gastric emptying
#>   - Organism|Lumen|Stomach|Dapagliflozin|Gastric retention
#>   - Organism|Lumen|Stomach|Metformin|Gastric retention distal
#>   - Organism|Lumen|Stomach|Metformin|Gastric retention proximal
#>   - Organism|Lumen|Stomach|Metformin|Gastric retention
#> Existing data will be overwriten.
```

<sup>Created on 2023-06-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Bonus: use of roxygen2 template for shared method/functions parameters.
