### PR TITLE
Add stopIfFails argument for runSimulation

### DIFF
--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -141,7 +141,7 @@ runSimulation <- function(simulation, population = NULL, agingData = NULL, simul
 #' @param agingData Optional instance of `AgingData` to use for the simulation.
 #' This is only used with a population simulation
 #' @param simulationRunOptions Optional instance of a `SimulationRunOptions` used during the simulation run
-#' @param silentMode If `TRUE`, no warnings are displayed if a simulation fails. Default is `FALSE`
+#' @inheritParams .getConcurrentSimulationRunnerResults
 #'
 #' @return A named list of `SimulationResults` objects with names being the IDs
 #' of the respective simulations. If a simulation fails, the result for this
@@ -173,7 +173,7 @@ runSimulation <- function(simulation, population = NULL, agingData = NULL, simul
 #' # Results is an array of `SimulationResults`
 #' results <- runSimulations(list(sim, sim2, sim3))
 #' @export
-runSimulations <- function(simulations, population = NULL, agingData = NULL, simulationRunOptions = NULL, silentMode = FALSE) {
+runSimulations <- function(simulations, population = NULL, agingData = NULL, simulationRunOptions = NULL, silentMode = FALSE, stopIfFails = FALSE) {
   simulations <- c(simulations)
   validateIsOfType(simulationRunOptions, "SimulationRunOptions", nullAllowed = TRUE)
   simulationRunOptions <- simulationRunOptions %||% SimulationRunOptions$new()
@@ -200,7 +200,8 @@ runSimulations <- function(simulations, population = NULL, agingData = NULL, sim
   return(.runSimulationsConcurrently(
     simulations = simulations,
     simulationRunOptions = simulationRunOptions,
-    silentMode = silentMode
+    silentMode = silentMode,
+    stopIfFails = stopIfFails
   ))
 }
 
@@ -233,7 +234,7 @@ runSimulations <- function(simulations, population = NULL, agingData = NULL, sim
   SimulationResults$new(results, simulation)
 }
 
-.runSimulationsConcurrently <- function(simulations, simulationRunOptions, silentMode = FALSE) {
+.runSimulationsConcurrently <- function(simulations, simulationRunOptions, silentMode = FALSE, stopIfFails = FALSE) {
   simulationRunner <- .getNetTask("ConcurrentSimulationRunner")
   tryCatch(
     {
@@ -257,7 +258,11 @@ runSimulations <- function(simulations, population = NULL, agingData = NULL, sim
       # Ids of the results are Ids of the simulations
       resultsIdSimulationIdMap <- names(simulationIdSimulationMap)
       names(resultsIdSimulationIdMap) <- names(simulationIdSimulationMap)
-      simulationResults <- .getConcurrentSimulationRunnerResults(results = results, resultsIdSimulationIdMap = resultsIdSimulationIdMap, simulationIdSimulationMap = simulationIdSimulationMap, silentMode = silentMode)
+      simulationResults <- .getConcurrentSimulationRunnerResults(results = results,
+                                                                 resultsIdSimulationIdMap = resultsIdSimulationIdMap,
+                                                                 simulationIdSimulationMap = simulationIdSimulationMap,
+                                                                 silentMode = silentMode,
+                                                                 stopIfFails = stopIfFails)
 
       return(simulationResults)
     },
@@ -335,8 +340,7 @@ createSimulationBatch <- function(simulation, parametersOrPaths = NULL, molecule
 #'
 #' @param simulationBatches List of `SimulationBatch` objects with added parameter and initial values
 #' @param simulationRunOptions Optional instance of a `SimulationRunOptions` used during the simulation run.
-#' @param silentMode If `TRUE`, no warnings are displayed if a simulation fails.
-#' Default is `FALSE`.
+#' @inheritParams .getConcurrentSimulationRunnerResults
 #'
 #' @return Nested list of `SimulationResults` objects. The first level of the
 #' fist are the IDs of the SimulationBatches, containing a list of
@@ -369,7 +373,7 @@ createSimulationBatch <- function(simulation, parametersOrPaths = NULL, molecule
 #' ids[[4]] <- simulationBatch2$addRunValues(parameterValues = c(2.6, 4.4), initialValues = 5)
 #' res <- runSimulationBatches(simulationBatches = list(simulationBatch1, simulationBatch2))
 #' }
-runSimulationBatches <- function(simulationBatches, simulationRunOptions = NULL, silentMode = FALSE) {
+runSimulationBatches <- function(simulationBatches, simulationRunOptions = NULL, silentMode = FALSE, stopIfFails = FALSE) {
   validateIsOfType(simulationBatches, "SimulationBatch")
   simulationRunner <- .getNetTask("ConcurrentSimulationRunner")
   validateIsOfType(simulationRunOptions, "SimulationRunOptions", nullAllowed = TRUE)
@@ -404,7 +408,8 @@ runSimulationBatches <- function(simulationBatches, simulationRunOptions = NULL,
     results = results,
     resultsIdSimulationIdMap = resultsIdSimulationBatchIdMap,
     simulationIdSimulationMap = simulationBatchIdSimulationMap,
-    silentMode = silentMode
+    silentMode = silentMode,
+    stopIfFails = stopIfFails
   )
 
   # Returned is a named list of results with names being the IDs of the batches
@@ -589,11 +594,12 @@ exportIndividualSimulations <- function(population, individualIds, outputFolder,
 #' @param resultsIdSimulationIdMap Map of results ids as keys with values being the ids of simulations the respective batch was created with. The order of IDs is as they were added to the batch.
 #' @param simulationIdSimulationMap A named list of simulation ids as keys and simulation objects as values
 #' to the id of a result
-#' @param silentMode If `TRUE`, no warnings are displayed if a simulation fails.
+#' @param silentMode If `TRUE`, no warnings are displayed if a simulation fails. Default is `FALSE`
+#' @param stopIfFails Wether to stop the execution if one of the simulation did not succeed. default to FALSE.
 #'
 #' @return A named list of `SimulationResults` objects with the names being the ids of simulations or
 #' simulation-batch values pairs they were produced by
-.getConcurrentSimulationRunnerResults <- function(results, resultsIdSimulationIdMap, simulationIdSimulationMap, silentMode) {
+.getConcurrentSimulationRunnerResults <- function(results, resultsIdSimulationIdMap, simulationIdSimulationMap, silentMode, stopIfFails) {
   # Pre-allocate lists for SimulationResult
   simulationResults <- vector("list", length(results))
   # Set the correct order of IDs
@@ -609,9 +615,11 @@ exportIndividualSimulations <- function(population, individualIds, outputFolder,
       simulationResults[[resultsId]] <- SimulationResults$new(ref = rClr::clrGet(resultObject, "Result"), simulation = simulationIdSimulationMap[[simId]])
       next()
     }
-    # If the simulation run failed, show a warning
-    if (!silentMode) {
-      errorMessage <- rClr::clrGet(resultObject, "ErrorMessage")
+    # If the simulation run failed, show a warning or an error
+    errorMessage <- rClr::clrGet(resultObject, "ErrorMessage")
+    if (stopIfFails) {
+      stop(errorMessage)
+    } else if (!silentMode) {
       warning(errorMessage)
     }
   }

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -594,8 +594,8 @@ exportIndividualSimulations <- function(population, individualIds, outputFolder,
 #' @param resultsIdSimulationIdMap Map of results ids as keys with values being the ids of simulations the respective batch was created with. The order of IDs is as they were added to the batch.
 #' @param simulationIdSimulationMap A named list of simulation ids as keys and simulation objects as values
 #' to the id of a result
-#' @param silentMode If `TRUE`, no warnings are displayed if a simulation fails. Default is `FALSE`
-#' @param stopIfFails Wether to stop the execution if one of the simulation did not succeed. default to FALSE.
+#' @param silentMode If `TRUE`, no warnings are displayed if a simulation fails. Default is `FALSE`. Has no effect if `stopIfFails` is `TRUE`.
+#' @param stopIfFails Whether to stop the execution if one of the simulations failed. Default is `FALSE`.
 #'
 #' @return A named list of `SimulationResults` objects with the names being the ids of simulations or
 #' simulation-batch values pairs they were produced by

--- a/man/dot-getConcurrentSimulationRunnerResults.Rd
+++ b/man/dot-getConcurrentSimulationRunnerResults.Rd
@@ -8,7 +8,8 @@
   results,
   resultsIdSimulationIdMap,
   simulationIdSimulationMap,
-  silentMode
+  silentMode,
+  stopIfFails
 )
 }
 \arguments{
@@ -19,7 +20,9 @@
 \item{simulationIdSimulationMap}{A named list of simulation ids as keys and simulation objects as values
 to the id of a result}
 
-\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails.}
+\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}}
+
+\item{stopIfFails}{Wether to stop the execution if one of the simulation did not succeed. default to FALSE.}
 }
 \value{
 A named list of \code{SimulationResults} objects with the names being the ids of simulations or

--- a/man/dot-getConcurrentSimulationRunnerResults.Rd
+++ b/man/dot-getConcurrentSimulationRunnerResults.Rd
@@ -20,9 +20,9 @@
 \item{simulationIdSimulationMap}{A named list of simulation ids as keys and simulation objects as values
 to the id of a result}
 
-\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}}
+\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}. Has no effect if \code{stopIfFails} is \code{TRUE}.}
 
-\item{stopIfFails}{Wether to stop the execution if one of the simulation did not succeed. default to FALSE.}
+\item{stopIfFails}{Whether to stop the execution if one of the simulations failed. Default is \code{FALSE}.}
 }
 \value{
 A named list of \code{SimulationResults} objects with the names being the ids of simulations or

--- a/man/runSimulationBatches.Rd
+++ b/man/runSimulationBatches.Rd
@@ -7,7 +7,8 @@
 runSimulationBatches(
   simulationBatches,
   simulationRunOptions = NULL,
-  silentMode = FALSE
+  silentMode = FALSE,
+  stopIfFails = FALSE
 )
 }
 \arguments{
@@ -15,8 +16,9 @@ runSimulationBatches(
 
 \item{simulationRunOptions}{Optional instance of a \code{SimulationRunOptions} used during the simulation run.}
 
-\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails.
-Default is \code{FALSE}.}
+\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}}
+
+\item{stopIfFails}{Wether to stop the execution if one of the simulation did not succeed. default to FALSE.}
 }
 \value{
 Nested list of \code{SimulationResults} objects. The first level of the

--- a/man/runSimulationBatches.Rd
+++ b/man/runSimulationBatches.Rd
@@ -16,9 +16,9 @@ runSimulationBatches(
 
 \item{simulationRunOptions}{Optional instance of a \code{SimulationRunOptions} used during the simulation run.}
 
-\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}}
+\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}. Has no effect if \code{stopIfFails} is \code{TRUE}.}
 
-\item{stopIfFails}{Wether to stop the execution if one of the simulation did not succeed. default to FALSE.}
+\item{stopIfFails}{Whether to stop the execution if one of the simulations failed. Default is \code{FALSE}.}
 }
 \value{
 Nested list of \code{SimulationResults} objects. The first level of the

--- a/man/runSimulations.Rd
+++ b/man/runSimulations.Rd
@@ -9,7 +9,8 @@ runSimulations(
   population = NULL,
   agingData = NULL,
   simulationRunOptions = NULL,
-  silentMode = FALSE
+  silentMode = FALSE,
+  stopIfFails = FALSE
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ This is only used with a population simulation}
 \item{simulationRunOptions}{Optional instance of a \code{SimulationRunOptions} used during the simulation run}
 
 \item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}}
+
+\item{stopIfFails}{Wether to stop the execution if one of the simulation did not succeed. default to FALSE.}
 }
 \value{
 A named list of \code{SimulationResults} objects with names being the IDs

--- a/man/runSimulations.Rd
+++ b/man/runSimulations.Rd
@@ -27,9 +27,9 @@ This is only used with a population simulation}
 
 \item{simulationRunOptions}{Optional instance of a \code{SimulationRunOptions} used during the simulation run}
 
-\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}}
+\item{silentMode}{If \code{TRUE}, no warnings are displayed if a simulation fails. Default is \code{FALSE}. Has no effect if \code{stopIfFails} is \code{TRUE}.}
 
-\item{stopIfFails}{Wether to stop the execution if one of the simulation did not succeed. default to FALSE.}
+\item{stopIfFails}{Whether to stop the execution if one of the simulations failed. Default is \code{FALSE}.}
 }
 \value{
 A named list of \code{SimulationResults} objects with names being the IDs

--- a/tests/testthat/test-utilities-simulation.R
+++ b/tests/testthat/test-utilities-simulation.R
@@ -201,11 +201,20 @@ test_that("It does not show a warning if one of simulations fails in silent mode
   sim2 <- loadTestSimulation("S1", loadFromCache = FALSE)
   sim$solver$relTol <- 1000
 
-  expect_warning(results <- runSimulations(simulations = c(sim, sim2), silentMode = TRUE), regexp = NA)
+  expect_no_warning(results <- runSimulations(simulations = c(sim, sim2), silentMode = TRUE))
   expect_equal(length(results), 2)
   expect_equal(names(results)[[2]], sim2$id)
   expect_null(results[[sim$id]])
   expect_true(isOfType(results[[2]], "SimulationResults"))
+})
+
+test_that("Show an error when a simulations fails.", {
+  resetSimulationCache()
+  sim <- loadTestSimulation("S1", loadFromCache = FALSE)
+  sim2 <- loadTestSimulation("S1", loadFromCache = FALSE)
+  sim$solver$relTol <- 1000
+
+  expect_error(runSimulations(simulations = c(sim, sim2), stopIfFails = TRUE))
 })
 
 test_that("It throws an error when running multiple simulations with a population", {
@@ -392,6 +401,20 @@ test_that("It can run a simulation batch, add new values, and run again", {
   expect_true(isOfType(res[[1]][[1]], "SimulationResults"))
   expect_equal(names(res[[1]])[[1]], ids[[1]])
   expect_equal(names(res[[1]])[[2]], ids[[2]])
+})
+
+test_that("It does not show a warning when simulation fails in silentMode", {
+  molecules <- "Organism|Liver|A"
+  simulationBatch <- createSimulationBatch(sim, moleculesOrPaths = molecules)
+  id <- simulationBatch$addRunValues(initialValues = c(1, 1.2))
+  expect_no_warning(runSimulationBatches(simulationBatch, silentMode = TRUE))
+})
+
+test_that("Throws an error when a simulation does not succeed", {
+  molecules <- "Organism|Liver|A"
+  simulationBatch <- createSimulationBatch(sim, moleculesOrPaths = molecules)
+  id <- simulationBatch$addRunValues(initialValues = c(1, 1.2))
+  expect_error(runSimulationBatches(simulationBatch, stopIfFails = TRUE))
 })
 
 context("getAllStateVariablesPaths")


### PR DESCRIPTION
 Implements #1217 

The silentMode argument was kept. Error is still thrown when silentMode is enabled.


``` r
devtools::load_all(".")
#> ℹ Loading ospsuite
#> Loading required package: rClr
#> 
#> Loading the dynamic library for Microsoft .NET runtime...
#> Loaded Common Language Runtime version 4.0.30319.42000

sim <- loadTestSimulation("S1", loadFromCache = FALSE)
sim2 <- loadTestSimulation("S1", loadFromCache = FALSE)
sim$solver$relTol <- 1000

# Run Simulations with error will be displayed as warning
res <- runSimulations(simulations = c(sim, sim2))
#> Warning in .getConcurrentSimulationRunnerResults(results = results, resultsIdSimulationIdMap = resultsIdSimulationIdMap, : Simulation run failed: some variables became negative when trying to reach t=3. There are different possible reasons for this:
#> 
#>   - Solver tolerances are too high. Please reduce the absolute and relative tolerances by one order of magnitude (e.g. from 1E-9 to 1E-10) and restart the simulation.
#>   - Some variables which are allowed to be negative were defined as non-negative.
#>   - Model is not properly established (e.g. the kinetic should be k*[A] but was defined as k*[B] etc.)
#> 
#> The following variables became negative :
#> S1|Organism|Gonads|Intracellular|Caffeine-CYP1A2-MM Metabolite
#> S1|Organism|Kidney|Intracellular|Caffeine-CYP1A2-MM Metabolite
#> S1|Organism|Liver|Periportal|Intracellular|Caffeine-CYP1A2-MM Metabolite
#> S1|Organism|Lung|Intracellular|Caffeine-CYP1A2-MM Metabolite

# Warning is hidden in silentMode
res <- runSimulations(simulations = c(sim, sim2), silentMode = TRUE)

# Run Simulations will stop with stopIfFails is enabled
res <- runSimulations(simulations = c(sim, sim2), stopIfFails = TRUE)
#> Error in .getConcurrentSimulationRunnerResults(results = results, resultsIdSimulationIdMap = resultsIdSimulationIdMap, : Simulation run failed: some variables became negative when trying to reach t=3. There are different possible reasons for this:
#> 
#>   - Solver tolerances are too high. Please reduce the absolute and relative tolerances by one order of magnitude (e.g. from 1E-9 to 1E-10) and restart the simulation.
#>   - Some variables which are allowed to be negative were defined as non-negative.
#>   - Model is not properly established (e.g. the kinetic should be k*[A] but was defined as k*[B] etc.)
#> 
#> The following variables became negative :
#> S1|Organism|Gonads|Intracellular|Caffeine-CYP1A2-MM Metabolite
#> S1|Organism|Kidney|Intracellular|Caffeine-CYP1A2-MM Metabolite
#> S1|Organism|Liver|Periportal|Intracellular|Caffeine-CYP1A2-MM Metabolite
#> S1|Organism|Lung|Intracellular|Caffeine-CYP1A2-MM Metabolite

# Identical for runSimulationBatches
sim <- loadTestSimulation("simple", loadFromCache = TRUE)
molecules <- "Organism|Liver|A"
simulationBatch <- createSimulationBatch(sim, moleculesOrPaths = molecules)
id <- simulationBatch$addRunValues(initialValues = c(1, 1.2))
res <- runSimulationBatches(simulationBatch, stopIfFails = TRUE)
#> Error in .getConcurrentSimulationRunnerResults(results = results, resultsIdSimulationIdMap = resultsIdSimulationBatchIdMap, : No the expected number of initial values (1 vs 2)
```

<sup>Created on 2023-06-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
