### PR TITLE
Force linesColor to black for ObsVsPred, ResVsTime & ResVsPred plots

### DIFF
--- a/R/utilities-plotting.R
+++ b/R/utilities-plotting.R
@@ -422,7 +422,7 @@
 
   # For `plotObservedVsSimulated()`
   if (plotType == "ObsVsPredPlotConfiguration") {
-    generalPlotConfiguration$linesColor <- generalPlotConfiguration$linesColor %||% "black"
+    generalPlotConfiguration$linesColor <- "black"
     generalPlotConfiguration$legendPosition <- generalPlotConfiguration$legendPosition %||% tlf::LegendPositions$insideBottomRight
     generalPlotConfiguration$xAxisScale <- generalPlotConfiguration$xAxisScale %||% tlf::Scaling$log
     generalPlotConfiguration$yAxisScale <- generalPlotConfiguration$yAxisScale %||% tlf::Scaling$log
@@ -432,7 +432,7 @@
 
   # For `plotResidualsVsTime()` and `plotResidualsVsSimulated()`
   if (plotType %in% c("ResVsTimePlotConfiguration", "ResVsPredPlotConfiguration")) {
-    generalPlotConfiguration$linesColor <- generalPlotConfiguration$linesColor %||% "black"
+    generalPlotConfiguration$linesColor <- "black"
     generalPlotConfiguration$linesLinetype <- generalPlotConfiguration$linesLinetype %||% tlf::Linetypes$dashed
     generalPlotConfiguration$xAxisScale <- generalPlotConfiguration$xAxisScale %||% tlf::Scaling$lin
     generalPlotConfiguration$yAxisScale <- generalPlotConfiguration$yAxisScale %||% tlf::Scaling$lin


### PR DESCRIPTION
With these changes, static lines (identify, fold ...) are forced to "black" for certain type of plots no matter the values of `$linesColor` is.


## Demo

### Custom plotConfiguration
pointsColor & linesColors are changed

```
myPlotConfiguration <- DefaultPlotConfiguration$new()

new_colors <- viridis::viridis(3)
myPlotConfiguration$pointsColor <- new_colors
myPlotConfiguration$linesColor <- new_colors
```

### Effect on plotIndividualTimeProfile
``` r
manyObsSimDC <- readRDS(getTestDataFilePath("manyObsSimDC"))

plotIndividualTimeProfile(manyObsSimDC, myPlotConfiguration)
```

![](https://i.imgur.com/E9cSq0e.png)<!-- -->

> **✅ Lines & Points have custom colors**


# Effect on Obs vs Pred 
``` r
sim <- loadTestSimulation("MinimalModel")
simResults <- importResultsFromCSV(
  simulation = sim,
  filePaths = getTestDataFilePath("Stevens_2012_placebo_indiv_results.csv")
)
dataSet <- loadDataSetsFromExcel(
  xlsFilePath = getTestDataFilePath("CompiledDataSetStevens2012.xlsx"),
  importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath("ImporterConfiguration.xml"))
)
myCombDat <- DataCombined$new()
myCombDat$addDataSets(dataSet)
myCombDat$addSimulationResults(
  simResults,
  quantitiesOrPaths = c(
    "Organism|Lumen|Stomach|Metformin|Gastric retention",
    "Organism|Lumen|Stomach|Metformin|Gastric retention distal",
    "Organism|Lumen|Stomach|Metformin|Gastric retention proximal"
  )
)

myCombDat$setGroups(
  names = c(
    "Organism|Lumen|Stomach|Metformin|Gastric retention",
    "Organism|Lumen|Stomach|Metformin|Gastric retention distal",
    "Organism|Lumen|Stomach|Metformin|Gastric retention proximal",
    "Stevens_2012_placebo.Placebo_total",
    "Stevens_2012_placebo.Placebo_distal",
    "Stevens_2012_placebo.Placebo_proximal"
  ),
  groups = c("Solid total", "Solid distal", "Solid proximal", "Solid total", "Solid distal", "Solid proximal")
)

plotObservedVsSimulated(myCombDat, 
                        myPlotConfiguration, 
                        foldDistance = c(2,3,4))
#> Following datasets were specified to be grouped but not found:
#> Stevens_2012_placebo.Sita_dist
#> Stevens_2012_placebo.Sita_proximal
#> Stevens_2012_placebo.Sita_total
```

![](https://i.imgur.com/0eaBwxZ.png)<!-- -->

> **✅ Static lines are still black while points have custom colors**
