### PR TITLE
A new `silent` flag in DataCombined$addSimulationResults() method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ and https://github.com/Open-Systems-Pharmacology/OSPSuite-R/issues/1087.
   `yAxisLimits`. Use them to zoom in the plot while preserving all data points.
   Use `xValuesLimits` and `yValuesLimits` to filter out data point outside of these range. 
   More detailed explanations [here](https://ggplot2.tidyverse.org/reference/coord_cartesian.html#ref-examples)
+- `addSimulationResults` method of the `DataCombined` class now supports an optional `silent` argument which silences the checks for data set names. If you expect to replace data sets in `DataCombined` objects repeatedly, consider switching the parameter from the default `FALSE` value to `TRUE`. 
 
 # ospsuite 11.1.197
 

--- a/R/data-combined.R
+++ b/R/data-combined.R
@@ -135,13 +135,17 @@ DataCombined <- R6::R6Class(
     #'
     #' @template simulation_results
     #'
+    #' @param silent A binary flag showing if warnings should be triggered when
+    #' data sets are overwritten in the `DataCombined` object
+    #'
     #' @return `DataCombined` object containing simulated data.
     addSimulationResults = function(simulationResults,
                                     quantitiesOrPaths = NULL,
                                     population = NULL,
                                     individualIds = NULL,
                                     names = NULL,
-                                    groups = NULL) {
+                                    groups = NULL,
+                                    silent = FALSE) {
       # Validate vector arguments' type and length
       validateIsOfType(simulationResults, "SimulationResults", FALSE)
 
@@ -170,7 +174,12 @@ DataCombined <- R6::R6Class(
         names <- ifelse(is.na(names), pathsNames, names)
       }
 
-      private$.verifyExistingNames(newNames = c(pathsNames, names))
+      # If the names are expected to be the same (replacing the data sets multiple times),
+      # a `silent` flag can be passed to silence warnings.
+      # By default, the warnings will be issued (`silent` set to `FALSE`).
+      if (!silent) {
+        private$.verifyExistingNames(newNames = c(pathsNames, names))
+      }
 
       # Update private fields and bindings for the new setter call
 

--- a/man/DataCombined.Rd
+++ b/man/DataCombined.Rd
@@ -142,7 +142,8 @@ Add simulated data using instance of \code{SimulationResults} class.
   population = NULL,
   individualIds = NULL,
   names = NULL,
-  groups = NULL
+  groups = NULL,
+  silent = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -183,6 +184,9 @@ entry in the \code{group} column will be an \code{NA}). If provided, \code{group
 have the same length as \code{dataSets} and/or \code{simulationResults$quantityPath}.
 If no grouping is specified for any of the dataset, the column \code{group} in
 the data frame output will be all \code{NA}.}
+
+\item{\code{silent}}{A binary flag showing if warnings should be triggered when
+data sets are overwritten in the \code{DataCombined} object}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-data-combined.R
+++ b/tests/testthat/test-data-combined.R
@@ -642,6 +642,12 @@ test_that("it shows a warning when a dataset is added with the same name as a da
   expect_warning(dc$addSimulationResults(simResults))
 })
 
+test_that("The warning can be explicitly silenced", {
+  dc <- DataCombined$new()
+  dc$addSimulationResults(simResults)
+  expect_no_warning(dc$addSimulationResults(simResults, silent = TRUE))
+})
+
 # data transformations --------------------------
 
 test_that("data transformations don't work with arguments of wrong length", {


### PR DESCRIPTION
For parameter identification purposes, I am often repeatedly replacing the simulation results in the same `DataCombined` object with new simulation results. By default, this triggers a warning about replacing the data set with the same name. I want to be able to silence this warning when needed.