### PR TITLE
Use master branch of PK-Sim

### DIFF
--- a/appveyor-3.6.yml
+++ b/appveyor-3.6.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2019
 # uncomment to use global ospsuite version (and comment line underneath)
 # version: '{build}'
 version: '11.2.{build}'
+pkSim_branch: 'master'
 
 # Download script file from GitHub
 init:
@@ -34,7 +35,7 @@ before_build:
   - nuget sources add -name core -source https://ci.appveyor.com/nuget/ospsuite-core
   - nuget sources add -name centos -source https://ci.appveyor.com/nuget/ospsuite-centos
   - nuget install packages.config -OutputDirectory packages # cannot use automatic artifact publish because it's not recognized in a C++/CLI project
-  - rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
+  - rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%, %pkSim_branch$%]"
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor-nightly.yml
+++ b/appveyor-nightly.yml
@@ -62,7 +62,7 @@ test_script:
 after_test:
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, ubuntu18]"
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, centOS7]"
-  - rake "download_portable[develop]"
+  - rake "download_portable[master]"
   - appveyor PushArtifact "C:/projects/ospsuite-r/pksim_minimal.zip"
   - ps: copy ospsuite_*.zip ospsuite.zip
   - ps: copy ospsuite_*ubuntu18.tar.gz ospsuite_ubuntu18.tar.gz

--- a/appveyor-nightly.yml
+++ b/appveyor-nightly.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2019
 # uncomment to use global ospsuite version (and comment line underneath)
 # version: '{build}'
 version: '11.2.{build}'
+pkSim_branch: 'master'
 
 # Download script file from GitHub
 init:
@@ -41,7 +42,7 @@ before_build:
   - nuget sources add -name core -source https://ci.appveyor.com/nuget/ospsuite-core
   - nuget sources add -name centos -source https://ci.appveyor.com/nuget/ospsuite-centos
   - nuget install packages.config -OutputDirectory packages # cannot use automatic artifact publish because it's not recognized in a C++/CLI project
-  - rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
+  - rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%, %pkSim_branch%]"
 
 build_script:
   - travis-tool.sh install_deps
@@ -62,7 +63,7 @@ test_script:
 after_test:
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, ubuntu18]"
   - rake "create_linux_build[%APPVEYOR_BUILD_VERSION%, %APPVEYOR_BUILD_FOLDER%, centOS7]"
-  - rake "download_portable[master]"
+  - rake "download_portable[%pkSim_branch%]"
   - appveyor PushArtifact "C:/projects/ospsuite-r/pksim_minimal.zip"
   - ps: copy ospsuite_*.zip ospsuite.zip
   - ps: copy ospsuite_*ubuntu18.tar.gz ospsuite_ubuntu18.tar.gz

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -11,7 +11,7 @@ OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 APPVEYOR_ACCOUNT_NAME = 'open-systems-pharmacology-ci'
 
 task :prepare_for_build, [:build_version, :pksim_branch] do |t, args|
-  args.with_defaults(:pksim_branch => 'develop')
+  args.with_defaults(:pksim_branch => 'master')
   update_package_version(args.build_version, description_file)
   install_pksim(args.pksim_branch)
 end
@@ -21,7 +21,7 @@ end
 # that are necessary to run OSPSuite-R without any further
 # PK-Sim installation.
 task :download_portable, [:pksim_branch] do |t, args|
-  args.with_defaults(:pksim_branch => 'develop')
+  args.with_defaults(:pksim_branch => 'master')
   download_pksim_portable(args.pksim_branch)
 end
 

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -11,7 +11,7 @@ OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 APPVEYOR_ACCOUNT_NAME = 'open-systems-pharmacology-ci'
 
 task :prepare_for_build, [:build_version, :pksim_branch] do |t, args|
-  args.with_defaults(:pksim_branch => 'master')
+  args.with_defaults(:pksim_branch => 'develop')
   update_package_version(args.build_version, description_file)
   install_pksim(args.pksim_branch)
 end
@@ -21,7 +21,7 @@ end
 # that are necessary to run OSPSuite-R without any further
 # PK-Sim installation.
 task :download_portable, [:pksim_branch] do |t, args|
-  args.with_defaults(:pksim_branch => 'master')
+  args.with_defaults(:pksim_branch => 'develop')
   download_pksim_portable(args.pksim_branch)
 end
 


### PR DESCRIPTION
Since we are using the released DLLs, use PK-Sim from master branch.

Is there anything else to change?