### PR TITLE
Hotfix 11.3 (the 2nd)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ BugReports:
     https://github.com/open-systems-pharmacology/ospsuite-r/issues
 Depends: 
     R (>= 3.6),
-    rClr (== 0.9.1)
+    rClr (>= 0.9.1)
 Imports: 
     dplyr (>= 1.0.0),
     ospsuite.utils (== 1.4.23),

--- a/appveyor-nightly.yml
+++ b/appveyor-nightly.yml
@@ -26,7 +26,7 @@ environment:
   NOT_CRAN: true
   KEEP_VIGNETTES: true
   R_ARCH: x64
-  R_VERSION: 4.1.0
+  R_VERSION: 4.3.1
   R_CHECK_ARGS: --no-multiarch --no-manual --as-cran
   COVERALLS_TOKEN:
     secure: xIz/WZT0ex3bs/CMBJTzzdXLhl3sqfSqJ3MshlSY03pZKuyYQN7Z1FprVgnlFMUZ
@@ -43,7 +43,7 @@ before_build:
   - rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%, hotfix/11.3]"
 
 build_script:
-  - Rscript -e "install.packages('https://github.com/Open-Systems-Pharmacology/rClr/releases/download/v0.9.1/rClr_0.9.1.zip', repos = NULL, type = 'binary')"
+  - Rscript -e "install.packages('https://github.com/Open-Systems-Pharmacology/rClr/releases/download/v0.9.2/rClr_0.9.2.zip', repos = NULL, type = 'binary')"
   - travis-tool.sh install_deps
   - travis-tool.sh r_binary_install curl
   - Rscript -e "install.packages('covr', repos = 'http://cran.us.r-project.org')"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,14 +26,14 @@ environment:
   R_BUILD_ARGS: --no-build-vignettes --no-manual
   R_CHECK_ARGS: --no-multiarch --no-manual --as-cran
   R_ARCH: x64
-  R_VERSION: 4.1.0
+  R_VERSION: 4.3.1
   #We use this variale to skip some long lasting tests using "skip_on_ci"
   CI: true 
 
 build_script:
   - travis-tool.sh install_deps
   - travis-tool.sh r_binary_install curl
-  - Rscript -e "install.packages('https://github.com/Open-Systems-Pharmacology/rClr/releases/download/v0.9.1/rClr_0.9.1.zip', repos = NULL, type = 'binary')"
+  - Rscript -e "install.packages('https://github.com/Open-Systems-Pharmacology/rClr/releases/download/v0.9.2/rClr_0.9.2.zip', repos = NULL, type = 'binary')"
   - Rscript -e "install.packages('https://github.com/Open-Systems-Pharmacology/OSPSuite.RUtils/releases/download/v1.4.23/ospsuite.utils_1.4.23.zip', repos = NULL, type = 'binary')"
   - Rscript -e "install.packages('https://github.com/Open-Systems-Pharmacology/TLF-Library/releases/download/v1.5.125/tlf_1.5.125.zip', repos = NULL, type = 'binary')"
   - Rscript -e "install.packages(c('ggplot2', 'patchwork', 'vdiffr', 'spelling'), repos = 'http://cran.us.r-project.org')"


### PR DESCRIPTION
* Allow rClr versions >0.9.1

* - Update R version used by AppVeyor to 4.3.1
- Update rClr used in Appveyor to 0.9.2

---------