### PR TITLE
pkgdown mode set to auto

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,7 +4,7 @@ template:
   bootstrap: 5
 
 development:
-  mode: devel
+  mode: auto
 
 authors:
   Open-Systems-Pharmacology Community:


### PR DESCRIPTION
With this change (`mode: auto`), the pkgdown github action will automatically build the main doc when version is X.Y.Z and update only the `dev` version when X.Y.Z.9000+

Previously, it was set to `devel` and so, all documentation changes were considerered as development version, thus, only updated in https://www.open-systems-pharmacology.org/OSPSuite-R/dev.

I will submit another PR to update the content of the gh-branch and update the website.