### PR TITLE
1152-auto-reduce-tolerances

### DIFF
--- a/R/simulation-run-options.R
+++ b/R/simulation-run-options.R
@@ -47,6 +47,10 @@ SimulationRunOptions <- R6::R6Class(
     #' @field showProgress  Specifies whether progress bar should be shown during simulation run. Default is `getOSPSuiteSetting("showProgress")`
     showProgress = function(value) {
       private$.wrapProperty("ShowProgress", value)
+    },
+    #' @field autoReduceTolerances Specifies whether tolerances should be automatically reduced if the simulation fails. Default is `TRUE`
+    autoReduceTolerances = function(value) {
+      private$.wrapProperty("AutoReduceTolerances", value)
     }
   )
 )

--- a/tests/testthat/test-simulation-run-options.R
+++ b/tests/testthat/test-simulation-run-options.R
@@ -13,3 +13,17 @@ test_that("It can set the basic options parameters", {
   runOptions$numberOfCores <- 5
   expect_equal(runOptions$numberOfCores, 5)
 })
+
+test_that("It can set autoReduceTolerances option correctly", {
+  runOptions <- SimulationRunOptions$new()
+  runOptions$autoReduceTolerances <- FALSE
+  sim <- loadSimulation(system.file("extdata", "Aciclovir.pkml", package = "ospsuite"), loadFromCache = FALSE)
+  # Setting relative tolerance to a high value to enforce error reduction
+  sim$solver$relTol <- 5
+  expect_error(runSimulations(sim))
+
+  # Allow reducing tolerances
+  runOptions$autoReduceTolerances <- TRUE
+  results <- runSimulations(simulations = sim)[[1]]
+  expect_equal(results$count, 1)
+})


### PR DESCRIPTION
Closes ##1152

- Added "AutoReduceTolerances" property to "SimulationRunOptions"
- Added test for auto reduce tolerances