### PR TITLE
feat: add suppressNameInLegend option to plot configurations

### DIFF
--- a/R/default-plot-configuration.R
+++ b/R/default-plot-configuration.R
@@ -147,6 +147,7 @@
 #' @field lloqDirection A string controlling how the LLOQ lines are plotted. Can be "vertical", "horizontal" or "both". Default to NULL to respect specific plot configurations.
 #' @field foldLinesLegend A Boolean controlling the drawing of the fold lines in the legend. Default to False.
 #' @field foldLinesLegendDiagonal A Boolean controlling whether the fold lines legend should be horizontal or diagonal lines.
+#' @field suppressNameInLegend A Boolean controlling whether to suppress the "name" mapping to linetype and shape in the legend.
 #' @examples
 #'
 #' # Create a new instance of this class
@@ -381,6 +382,9 @@ DefaultPlotConfiguration <- R6::R6Class(
 
     # Fold Distance Lines --------------------------
     foldLinesLegend = FALSE,
-    foldLinesLegendDiagonal = FALSE
+    foldLinesLegendDiagonal = FALSE,
+
+    # Mapping suppression in legend ---------------
+    suppressNameInLegend = TRUE
   )
 )

--- a/R/plot-individual-time-profile.R
+++ b/R/plot-individual-time-profile.R
@@ -46,8 +46,9 @@
 #' plotIndividualTimeProfile(myDataCombined, myPlotConfiguration)
 #'
 #' @export
-plotIndividualTimeProfile <- function(dataCombined,
-                                      defaultPlotConfiguration = NULL) {
+plotIndividualTimeProfile <- function(
+    dataCombined,
+    defaultPlotConfiguration = NULL) {
   .plotTimeProfile(dataCombined, defaultPlotConfiguration)
 }
 
@@ -56,13 +57,16 @@ plotIndividualTimeProfile <- function(dataCombined,
 #'
 #' @keywords internal
 #' @noRd
-.plotTimeProfile <- function(dataCombined,
-                             defaultPlotConfiguration = NULL,
-                             aggregation = NULL,
-                             ...) {
+.plotTimeProfile <- function(
+    dataCombined,
+    defaultPlotConfiguration = NULL,
+    aggregation = NULL,
+    ...) {
   # validation -----------------------------
 
-  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(defaultPlotConfiguration)
+  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(
+    defaultPlotConfiguration
+  )
 
   .validateDataCombinedForPlotting(dataCombined)
   if (is.null(dataCombined$groupMap)) {
@@ -80,7 +84,11 @@ plotIndividualTimeProfile <- function(dataCombined,
   # data frames -----------------------------
 
   # Getting all units on the same scale
-  combinedData <- convertUnits(dataCombined, defaultPlotConfiguration$xUnit, defaultPlotConfiguration$yUnit)
+  combinedData <- convertUnits(
+    dataCombined,
+    defaultPlotConfiguration$xUnit,
+    defaultPlotConfiguration$yUnit
+  )
 
   # Datasets which haven't been assigned to any group will be plotted as a group
   # on its own. That is, the `group` column entries for them will be their names.
@@ -88,11 +96,17 @@ plotIndividualTimeProfile <- function(dataCombined,
 
   # axes labels -----------------------------
 
-  timeProfilePlotConfiguration <- .updatePlotConfigurationAxesLabels(combinedData, timeProfilePlotConfiguration)
+  timeProfilePlotConfiguration <- .updatePlotConfigurationAxesLabels(
+    combinedData,
+    timeProfilePlotConfiguration
+  )
 
   # plot -----------------------------
 
-  obsData <- as.data.frame(dplyr::filter(combinedData, dataType == "observed"))
+  obsData <- as.data.frame(dplyr::filter(
+    combinedData,
+    dataType == "observed"
+  ))
 
   if (nrow(obsData) == 0) {
     obsData <- NULL
@@ -100,7 +114,10 @@ plotIndividualTimeProfile <- function(dataCombined,
     obsData <- .computeBoundsFromErrorType(obsData)
   }
 
-  simData <- as.data.frame(dplyr::filter(combinedData, dataType == "simulated"))
+  simData <- as.data.frame(dplyr::filter(
+    combinedData,
+    dataType == "simulated"
+  ))
 
   if (nrow(simData) == 0) {
     simData <- NULL
@@ -108,7 +125,11 @@ plotIndividualTimeProfile <- function(dataCombined,
 
   # Extract aggregated simulated data (relevant only for the population plot)
   if (!is.null(aggregation) && !is.null(simData)) {
-    simData <- as.data.frame(.extractAggregatedSimulatedData(simData, aggregation, ...))
+    simData <- as.data.frame(.extractAggregatedSimulatedData(
+      simData,
+      aggregation,
+      ...
+    ))
   }
 
   # To avoid repetition, assign column names to variables and use them instead
@@ -123,30 +144,41 @@ plotIndividualTimeProfile <- function(dataCombined,
   lloq <- NULL
   # Map LLOQ if defaultPlotConfiguration$displayLLOQ is set to TRUE and lloq
   # column contains at least one non NA value.
-  if (defaultPlotConfiguration$displayLLOQ & !all(is.na(unique(obsData$lloq)))) {
+  if (
+    defaultPlotConfiguration$displayLLOQ & !all(is.na(unique(obsData$lloq)))
+  ) {
     lloq <- "lloq"
   }
-
 
   # population time profile mappings with ribbon ------------------------------
 
   # The exact mappings chosen will depend on whether there are multiple datasets
   # of a given type present per group
   if (!is.null(aggregation)) {
-    simulatedDataMapping <- tlf::TimeProfileDataMapping$new(x, y, ymin, ymax,
+    simulatedDataMapping <- tlf::TimeProfileDataMapping$new(
+      x,
+      y,
+      ymin,
+      ymax,
       color = color,
       linetype = linetype,
       fill = fill
     )
     # individual time profile mappings ------------------------------------------
   } else {
-    simulatedDataMapping <- tlf::TimeProfileDataMapping$new(x, y,
+    simulatedDataMapping <- tlf::TimeProfileDataMapping$new(
+      x,
+      y,
       color = color,
       linetype = linetype
     )
   }
 
-  observedDataMapping <- tlf::ObservedDataMapping$new(x, y, ymin, ymax,
+  observedDataMapping <- tlf::ObservedDataMapping$new(
+    x,
+    y,
+    ymin,
+    ymax,
     shape = shape,
     color = color,
     lloq = lloq
@@ -162,8 +194,11 @@ plotIndividualTimeProfile <- function(dataCombined,
     plotConfiguration = timeProfilePlotConfiguration
   )
 
-  # Suppress certain mappings in the legend
-  profilePlot <- profilePlot + ggplot2::guides(linetype = "none", shape = "none")
+  # Suppress certain mappings in the legend based on configuration
+  if (defaultPlotConfiguration$suppressNameInLegend) {
+    profilePlot <- profilePlot +
+      ggplot2::guides(linetype = "none", shape = "none")
+  }
 
   return(profilePlot)
 }

--- a/R/plot-observed-vs-simulated.R
+++ b/R/plot-observed-vs-simulated.R
@@ -51,12 +51,15 @@
 #' # plot
 #' plotObservedVsSimulated(myDataCombined, myPlotConfiguration)
 #' @export
-plotObservedVsSimulated <- function(dataCombined,
-                                    defaultPlotConfiguration = NULL,
-                                    foldDistance = NULL) {
+plotObservedVsSimulated <- function(
+    dataCombined,
+    defaultPlotConfiguration = NULL,
+    foldDistance = NULL) {
   # validation -----------------------------
 
-  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(defaultPlotConfiguration)
+  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(
+    defaultPlotConfiguration
+  )
 
   .validateDataCombinedForPlotting(dataCombined)
   if (is.null(dataCombined$groupMap)) {
@@ -72,10 +75,9 @@ plotObservedVsSimulated <- function(dataCombined,
   )
 
   # Linear scaling is stored as identity scaling in `{tlf}`
-  is_any_scale_linear <- (
-    obsVsPredPlotConfiguration$xAxis$scale == tlf::Scaling$identity ||
-      obsVsPredPlotConfiguration$yAxis$scale == tlf::Scaling$identity
-  )
+  is_any_scale_linear <- (obsVsPredPlotConfiguration$xAxis$scale ==
+    tlf::Scaling$identity ||
+    obsVsPredPlotConfiguration$yAxis$scale == tlf::Scaling$identity)
 
   # Identity Line (x=y) definition. Its value depends on the scale:
   # - For linear scale: `1`
@@ -88,7 +90,10 @@ plotObservedVsSimulated <- function(dataCombined,
   } else {
     # foldDistance should be above 1
     if (any(foldDistance <= 1)) {
-      stop(messages$plotObservedVsSimulatedWrongFoldDistance("foldDistance", foldDistance))
+      stop(messages$plotObservedVsSimulatedWrongFoldDistance(
+        "foldDistance",
+        foldDistance
+      ))
     }
 
     # The argument `foldDistance` should only include fold values different from
@@ -109,7 +114,8 @@ plotObservedVsSimulated <- function(dataCombined,
   #
   # `DefaultPlotConfiguration` provides units for conversion.
   # `PlotConfiguration` provides scaling details needed while computing residuals.
-  pairedData <- calculateResiduals(dataCombined,
+  pairedData <- calculateResiduals(
+    dataCombined,
     scaling = obsVsPredPlotConfiguration$yAxis$scale,
     xUnit = defaultPlotConfiguration$xUnit,
     yUnit = defaultPlotConfiguration$yUnit
@@ -123,10 +129,14 @@ plotObservedVsSimulated <- function(dataCombined,
   # In logarithmic scale, if any of the values are `0`, plotting will fail.
   #
   # To avoid this, just remove rows where any of the quantities are `0`s.
-  if (obsVsPredPlotConfiguration$yAxis$scale %in% c(tlf::Scaling$log, tlf::Scaling$ln)) {
+  if (
+    obsVsPredPlotConfiguration$yAxis$scale %in%
+      c(tlf::Scaling$log, tlf::Scaling$ln)
+  ) {
     pairedData <- dplyr::filter(
       pairedData,
-      yValuesObserved != 0, yValuesSimulated != 0
+      yValuesObserved != 0,
+      yValuesSimulated != 0
     )
   }
 
@@ -157,7 +167,10 @@ plotObservedVsSimulated <- function(dataCombined,
 
   # axes labels -----------------------------
 
-  obsVsPredPlotConfiguration <- .updatePlotConfigurationAxesLabels(pairedData, obsVsPredPlotConfiguration)
+  obsVsPredPlotConfiguration <- .updatePlotConfigurationAxesLabels(
+    pairedData,
+    obsVsPredPlotConfiguration
+  )
 
   # plot -----------------------------
 
@@ -171,18 +184,23 @@ plotObservedVsSimulated <- function(dataCombined,
     dplyr::select(name, group) %>%
     dplyr::distinct() %>%
     dplyr::arrange(name) %>%
-    dplyr::mutate(shapeAssn = unlist(tlf::Shapes[obsVsPredPlotConfiguration$points$shape[1:nrow(.)]])) %>%
+    dplyr::mutate(
+      shapeAssn = unlist(tlf::Shapes[obsVsPredPlotConfiguration$points$shape[
+        1:nrow(.)
+      ]])
+    ) %>%
     dplyr::filter(!duplicated(group))
 
   # LLOQ is not mapped by default
   lloq <- NULL
   # Map LLOQ if defaultPlotConfiguration$displayLLOQ is set to TRUE and lloq
   # column contains at least one non NA value.
-  if (defaultPlotConfiguration$displayLLOQ & !all(is.na(unique(pairedData$lloq)))) {
+  if (
+    defaultPlotConfiguration$displayLLOQ &
+      !all(is.na(unique(pairedData$lloq)))
+  ) {
     lloq <- "lloq"
   }
-
-
 
   plotObject <- tlf::plotObsVsPred(
     data = as.data.frame(pairedData),
@@ -199,12 +217,21 @@ plotObservedVsSimulated <- function(dataCombined,
     plotConfiguration = obsVsPredPlotConfiguration
   )
 
-  return(plotObject + ggplot2::guides(
-    shape = "none",
-    col = ggplot2::guide_legend(
-      title = obsVsPredPlotConfiguration$legend$title$text,
-      title.theme = obsVsPredPlotConfiguration$legend$title$createPlotTextFont(),
-      override.aes = list(shape = overrideShapeAssignment$shapeAssn)
-    )
-  ))
+  return(
+    plotObject +
+      ggplot2::guides(
+        shape = if (defaultPlotConfiguration$suppressNameInLegend) {
+          "none"
+        } else {
+          "legend"
+        },
+        col = ggplot2::guide_legend(
+          title = obsVsPredPlotConfiguration$legend$title$text,
+          title.theme = obsVsPredPlotConfiguration$legend$title$createPlotTextFont(),
+          override.aes = list(
+            shape = overrideShapeAssignment$shapeAssn
+          )
+        )
+      )
+  )
 }

--- a/R/plot-residuals-vs-simulated.R
+++ b/R/plot-residuals-vs-simulated.R
@@ -50,21 +50,22 @@
 #' )
 #'
 #' @export
-plotResidualsVsSimulated <- function(dataCombined,
-                                     defaultPlotConfiguration = NULL,
-                                     scaling = "lin") {
+plotResidualsVsSimulated <- function(
+    dataCombined,
+    defaultPlotConfiguration = NULL,
+    scaling = "lin") {
   # validation -----------------------------
 
   rlang::arg_match(scaling, values = c("lin", "log"))
 
-  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(defaultPlotConfiguration)
+  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(
+    defaultPlotConfiguration
+  )
 
   .validateDataCombinedForPlotting(dataCombined)
   if (is.null(dataCombined$groupMap)) {
     return(NULL)
   }
-
-
 
   # `ResVsPredPlotConfiguration` object -----------------------------
 
@@ -86,7 +87,8 @@ plotResidualsVsSimulated <- function(dataCombined,
   #
   # `DefaultPlotConfiguration` provides units for conversion.
   # `PlotConfiguration` provides scaling details needed while computing residuals.
-  pairedData <- calculateResiduals(dataCombined,
+  pairedData <- calculateResiduals(
+    dataCombined,
     scaling = scaling,
     xUnit = defaultPlotConfiguration$xUnit,
     yUnit = defaultPlotConfiguration$yUnit
@@ -105,15 +107,25 @@ plotResidualsVsSimulated <- function(dataCombined,
     dplyr::select(name, group) %>%
     dplyr::distinct() %>%
     dplyr::arrange(name) %>%
-    dplyr::mutate(shapeAssn = unlist(tlf::Shapes[resVsPredPlotConfiguration$points$shape[1:nrow(.)]])) %>%
+    dplyr::mutate(
+      shapeAssn = unlist(tlf::Shapes[resVsPredPlotConfiguration$points$shape[
+        1:nrow(.)
+      ]])
+    ) %>%
     dplyr::filter(!duplicated(group))
 
   # axes labels -----------------------------
 
-  resVsPredPlotConfiguration <- .updatePlotConfigurationAxesLabels(pairedData, resVsPredPlotConfiguration)
+  resVsPredPlotConfiguration <- .updatePlotConfigurationAxesLabels(
+    pairedData,
+    resVsPredPlotConfiguration
+  )
 
   if (scaling == "log") {
-    resVsPredPlotConfiguration$labels$ylabel$text <- paste(resVsPredPlotConfiguration$labels$ylabel$text, "(log)")
+    resVsPredPlotConfiguration$labels$ylabel$text <- paste(
+      resVsPredPlotConfiguration$labels$ylabel$text,
+      "(log)"
+    )
   }
 
   # plot -----------------------------
@@ -129,12 +141,17 @@ plotResidualsVsSimulated <- function(dataCombined,
       shape = "name"
     ),
     plotConfiguration = resVsPredPlotConfiguration
-  ) + ggplot2::guides(
-    shape = "none",
-    col = ggplot2::guide_legend(
-      title = resVsPredPlotConfiguration$legend$title$text,
-      title.theme = resVsPredPlotConfiguration$legend$title$createPlotTextFont(),
-      override.aes = list(shape = overrideShapeAssignment$shapeAssn)
+  ) +
+    ggplot2::guides(
+      shape = if (defaultPlotConfiguration$suppressNameInLegend) {
+        "none"
+      } else {
+        "legend"
+      },
+      col = ggplot2::guide_legend(
+        title = resVsPredPlotConfiguration$legend$title$text,
+        title.theme = resVsPredPlotConfiguration$legend$title$createPlotTextFont(),
+        override.aes = list(shape = overrideShapeAssignment$shapeAssn)
+      )
     )
-  )
 }

--- a/R/plot-residuals-vs-time.R
+++ b/R/plot-residuals-vs-time.R
@@ -46,15 +46,17 @@
 #' plotResidualsVsTime(myDataCombined, scaling = "lin", defaultPlotConfiguration = myPlotConfiguration)
 #'
 #' @export
-plotResidualsVsTime <- function(dataCombined,
-                                defaultPlotConfiguration = NULL,
-                                scaling = "lin") {
+plotResidualsVsTime <- function(
+    dataCombined,
+    defaultPlotConfiguration = NULL,
+    scaling = "lin") {
   # validation -----------------------------
-
 
   rlang::arg_match(scaling, values = c("lin", "log"))
 
-  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(defaultPlotConfiguration)
+  defaultPlotConfiguration <- .validateDefaultPlotConfiguration(
+    defaultPlotConfiguration
+  )
 
   .validateDataCombinedForPlotting(dataCombined)
   if (is.null(dataCombined$groupMap)) {
@@ -81,7 +83,8 @@ plotResidualsVsTime <- function(dataCombined,
   #
   # `DefaultPlotConfiguration` provides units for conversion.
   # `PlotConfiguration` provides scaling details needed while computing residuals.
-  pairedData <- calculateResiduals(dataCombined,
+  pairedData <- calculateResiduals(
+    dataCombined,
     scaling = scaling,
     xUnit = defaultPlotConfiguration$xUnit,
     yUnit = defaultPlotConfiguration$yUnit
@@ -100,15 +103,25 @@ plotResidualsVsTime <- function(dataCombined,
     dplyr::select(name, group) %>%
     dplyr::distinct() %>%
     dplyr::arrange(name) %>%
-    dplyr::mutate(shapeAssn = unlist(tlf::Shapes[resVsTimePlotConfiguration$points$shape[1:nrow(.)]])) %>%
+    dplyr::mutate(
+      shapeAssn = unlist(tlf::Shapes[resVsTimePlotConfiguration$points$shape[
+        1:nrow(.)
+      ]])
+    ) %>%
     dplyr::filter(!duplicated(group))
 
   # axes labels -----------------------------
 
-  resVsTimePlotConfiguration <- .updatePlotConfigurationAxesLabels(pairedData, resVsTimePlotConfiguration)
+  resVsTimePlotConfiguration <- .updatePlotConfigurationAxesLabels(
+    pairedData,
+    resVsTimePlotConfiguration
+  )
 
   if (scaling == "log") {
-    resVsTimePlotConfiguration$labels$ylabel$text <- paste(resVsTimePlotConfiguration$labels$ylabel$text, "(log)")
+    resVsTimePlotConfiguration$labels$ylabel$text <- paste(
+      resVsTimePlotConfiguration$labels$ylabel$text,
+      "(log)"
+    )
   }
 
   # plot -----------------------------
@@ -124,12 +137,17 @@ plotResidualsVsTime <- function(dataCombined,
       shape = "name"
     ),
     plotConfiguration = resVsTimePlotConfiguration
-  ) + ggplot2::guides(
-    shape = "none",
-    col = ggplot2::guide_legend(
-      title = resVsTimePlotConfiguration$legend$title$text,
-      title.theme = resVsTimePlotConfiguration$legend$title$createPlotTextFont(),
-      override.aes = list(shape = overrideShapeAssignment$shapeAssn)
+  ) +
+    ggplot2::guides(
+      shape = if (defaultPlotConfiguration$suppressNameInLegend) {
+        "none"
+      } else {
+        "legend"
+      },
+      col = ggplot2::guide_legend(
+        title = resVsTimePlotConfiguration$legend$title$text,
+        title.theme = resVsTimePlotConfiguration$legend$title$createPlotTextFont(),
+        override.aes = list(shape = overrideShapeAssignment$shapeAssn)
+      )
     )
-  )
 }

--- a/tests/testthat/test-default-plot-configuration.R
+++ b/tests/testthat/test-default-plot-configuration.R
@@ -21,3 +21,16 @@ test_that("Defaults of the plot configuration", {
 
   expect_snapshot(myPlotConfiguration)
 })
+
+test_that("suppressNameInLegend default is TRUE", {
+  myPlotConfiguration <- DefaultPlotConfiguration$new()
+
+  expect_true(myPlotConfiguration$suppressNameInLegend)
+})
+
+test_that("suppressNameInLegend can be set to FALSE", {
+  myPlotConfiguration <- DefaultPlotConfiguration$new()
+  myPlotConfiguration$suppressNameInLegend <- FALSE
+
+  expect_false(myPlotConfiguration$suppressNameInLegend)
+})

--- a/tests/testthat/test-plot-individual-time-profile.R
+++ b/tests/testthat/test-plot-individual-time-profile.R
@@ -109,9 +109,12 @@ test_that("It returns `NULL` when `DataCombined` is empty", {
 test_that("LLOQ is plotted", {
   set.seed(42)
   dataSet <- DataSet$new("ds with lloq")
-  dataSet$setValues(1:7, c(10 * exp(1:-5) + rnorm(7, 0, .25)), abs(rnorm(7, 0, 0.1)))
+  dataSet$setValues(
+    1:7,
+    c(10 * exp(1:-5) + rnorm(7, 0, .25)),
+    abs(rnorm(7, 0, 0.1))
+  )
   dataSet$LLOQ <- 0.15
-
 
   dc <- DataCombined$new()
   dc$addDataSets(dataSet)
@@ -129,6 +132,41 @@ test_that("LLOQ is plotted", {
 
   vdiffr::expect_doppelganger(
     title = "no lloq",
-    fig = plotIndividualTimeProfile(dc, defaultPlotConfiguration = noLLOQ_DPC)
+    fig = plotIndividualTimeProfile(
+      dc,
+      defaultPlotConfiguration = noLLOQ_DPC
+    )
+  )
+})
+
+# Name mapping in legend
+
+test_that("Name mapping in legend can be controlled", {
+  # Create a test configuration with suppressNameInLegend set to FALSE
+  showNameConfig <- DefaultPlotConfiguration$new()
+  showNameConfig$suppressNameInLegend <- FALSE
+
+  # Create a test configuration with suppressNameInLegend set to TRUE (default)
+  hideNameConfig <- DefaultPlotConfiguration$new()
+  hideNameConfig$suppressNameInLegend <- TRUE
+
+  set.seed(123)
+
+  # Test with name visible in legend
+  vdiffr::expect_doppelganger(
+    title = "name shown in legend",
+    fig = plotIndividualTimeProfile(
+      manyObsSimDC,
+      defaultPlotConfiguration = showNameConfig
+    )
+  )
+
+  # Test with name hidden in legend (default behavior)
+  vdiffr::expect_doppelganger(
+    title = "name hidden in legend",
+    fig = plotIndividualTimeProfile(
+      manyObsSimDC,
+      defaultPlotConfiguration = hideNameConfig
+    )
   )
 })

--- a/tests/testthat/test-plot-observed-vs-simulated.R
+++ b/tests/testthat/test-plot-observed-vs-simulated.R
@@ -2,7 +2,6 @@
 
 # plotObservedVsSimulated
 
-
 # load the simulation
 sim <- loadTestSimulation("MinimalModel")
 simResults <- importResultsFromCSV(
@@ -13,7 +12,9 @@ simResults <- importResultsFromCSV(
 # import observed data (will return a list of `DataSet` objects)
 dataSet <- loadDataSetsFromExcel(
   xlsFilePath = getTestDataFilePath("CompiledDataSetStevens2012.xlsx"),
-  importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath("ImporterConfiguration.xml"))
+  importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath(
+    "ImporterConfiguration.xml"
+  ))
 )
 
 # create a new instance and add datasets
@@ -37,16 +38,31 @@ myCombDat$setGroups(
     "Stevens_2012_placebo.Placebo_distal",
     "Stevens_2012_placebo.Placebo_proximal"
   ),
-  groups = c("Solid total", "Solid distal", "Solid proximal", "Solid total", "Solid distal", "Solid proximal")
+  groups = c(
+    "Solid total",
+    "Solid distal",
+    "Solid proximal",
+    "Solid total",
+    "Solid distal",
+    "Solid proximal"
+  )
 )
 
 test_that("It throws an error when foldDistance is lower that 1", {
-  expect_error(plotObservedVsSimulated(myCombDat, foldDistance = 0.5),
-    regexp = messages$plotObservedVsSimulatedWrongFoldDistance("foldDistance", 0.5)
+  expect_error(
+    plotObservedVsSimulated(myCombDat, foldDistance = 0.5),
+    regexp = messages$plotObservedVsSimulatedWrongFoldDistance(
+      "foldDistance",
+      0.5
+    )
   )
 
-  expect_error(plotObservedVsSimulated(myCombDat, foldDistance = c(1, 0.5)),
-    regexp = messages$plotObservedVsSimulatedWrongFoldDistance("foldDistance", c(1, 0.5))
+  expect_error(
+    plotObservedVsSimulated(myCombDat, foldDistance = c(1, 0.5)),
+    regexp = messages$plotObservedVsSimulatedWrongFoldDistance(
+      "foldDistance",
+      c(1, 0.5)
+    )
   )
 })
 
@@ -90,7 +106,11 @@ test_that("It issues warning when scale is linear", {
   set.seed(123)
 
   testthat::expect_warning({
-    plot <- plotObservedVsSimulated(myCombDat, myPlotConfiguration, foldDistance = c(2, 4, 6))
+    plot <- plotObservedVsSimulated(
+      myCombDat,
+      myPlotConfiguration,
+      foldDistance = c(2, 4, 6)
+    )
   })
 
   vdiffr::expect_doppelganger(
@@ -149,14 +169,24 @@ test_that("It respects custom plot configuration", {
 })
 
 test_that("It produces expected plot for Aciclovir data", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simResults <- runSimulations(sim)[[1]]
 
   obsData <- lapply(
-    c("ObsDataAciclovir_1.pkml", "ObsDataAciclovir_2.pkml", "ObsDataAciclovir_3.pkml"),
-    function(x) loadDataSetFromPKML(system.file("extdata", x, package = "ospsuite"))
+    c(
+      "ObsDataAciclovir_1.pkml",
+      "ObsDataAciclovir_2.pkml",
+      "ObsDataAciclovir_3.pkml"
+    ),
+    function(x) {
+      loadDataSetFromPKML(system.file("extdata", x, package = "ospsuite"))
+    }
   )
 
   names(obsData) <- lapply(obsData, function(x) x$name)
@@ -172,7 +202,10 @@ test_that("It produces expected plot for Aciclovir data", {
   )
 
   # Add observed data set
-  myDataCombined$addDataSets(obsData$`Vergin 1995.Iv`, groups = "Aciclovir PVB")
+  myDataCombined$addDataSets(
+    obsData$`Vergin 1995.Iv`,
+    groups = "Aciclovir PVB"
+  )
 
   set.seed(123)
   vdiffr::expect_doppelganger(
@@ -194,21 +227,32 @@ test_that("It returns `NULL` when `DataCombined` is empty", {
 })
 
 test_that("It doesn't extrapolate past maximum simulated time point", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simData <- withr::with_tempdir({
     df <- dplyr::tibble(
       IndividualId = c(0, 0, 0),
       `Time [min]` = c(0, 2, 4),
-      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(0, 4, 8)
+      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(
+        0,
+        4,
+        8
+      )
     )
     readr::write_csv(df, "SimResults.csv")
     importResultsFromCSV(sim, "SimResults.csv")
   })
 
   obsData <- DataSet$new(name = "Observed")
-  obsData$setValues(xValues = c(1, 3, 3.5, 4, 5), yValues = c(1.9, 6.1, 7, 8.2, 1))
+  obsData$setValues(
+    xValues = c(1, 3, 3.5, 4, 5),
+    yValues = c(1.9, 6.1, 7, 8.2, 1)
+  )
   obsData$xUnit <- "min"
 
   myDC <- DataCombined$new()
@@ -239,21 +283,32 @@ test_that("It returns `NULL` when `DataCombined` doesn't have any pairable datas
 })
 
 test_that("Different symbols for data sets within one group", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simData <- withr::with_tempdir({
     df <- dplyr::tibble(
       IndividualId = c(0, 0, 0),
       `Time [min]` = c(0, 2, 4),
-      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(0, 4, 8)
+      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(
+        0,
+        4,
+        8
+      )
     )
     readr::write_csv(df, "SimResults.csv")
     importResultsFromCSV(sim, "SimResults.csv")
   })
 
   obsData <- DataSet$new(name = "Observed")
-  obsData$setValues(xValues = c(1, 3, 3.5, 4, 5), yValues = c(1.9, 6.1, 7, 8.2, 1))
+  obsData$setValues(
+    xValues = c(1, 3, 3.5, 4, 5),
+    yValues = c(1.9, 6.1, 7, 8.2, 1)
+  )
   obsData$xUnit <- "min"
   obsData$yDimension <- ospDimensions$`Concentration (molar)`
 
@@ -263,7 +318,10 @@ test_that("Different symbols for data sets within one group", {
 
   # Add second obs data
   obsData2 <- DataSet$new(name = "Observed 2")
-  obsData2$setValues(xValues = c(0, 3, 4, 4.5, 5.5), yValues = c(2.9, 5.1, 3, 8.2, 1))
+  obsData2$setValues(
+    xValues = c(0, 3, 4, 4.5, 5.5),
+    yValues = c(2.9, 5.1, 3, 8.2, 1)
+  )
   obsData2$xUnit <- "min"
   obsData2$yDimension <- ospDimensions$`Concentration (molar)`
   myDC$addDataSets(obsData2, groups = "myGroup")
@@ -276,21 +334,32 @@ test_that("Different symbols for data sets within one group", {
 })
 
 test_that("LLOQ is plotted", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simData <- withr::with_tempdir({
     df <- dplyr::tibble(
       IndividualId = c(0, 0, 0),
       `Time [min]` = c(0, 2, 4),
-      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(0, 4, 8)
+      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(
+        0,
+        4,
+        8
+      )
     )
     readr::write_csv(df, "SimResults.csv")
     importResultsFromCSV(sim, "SimResults.csv")
   })
 
   obsData <- DataSet$new(name = "Observed")
-  obsData$setValues(xValues = c(1, 3, 3.5, 4, 5), yValues = c(1.9, 6.1, 7, 8.2, 1))
+  obsData$setValues(
+    xValues = c(1, 3, 3.5, 4, 5),
+    yValues = c(1.9, 6.1, 7, 8.2, 1)
+  )
   obsData$xUnit <- "min"
   obsData$yDimension <- ospDimensions$`Concentration (molar)`
   obsData$LLOQ <- 3
@@ -309,9 +378,42 @@ test_that("LLOQ is plotted", {
   DPC$lloqDirection <- "both"
   vdiffr::expect_doppelganger(
     title = "lloq both direction",
-    fig = plotObservedVsSimulated(myDC,
+    fig = plotObservedVsSimulated(
+      myDC,
       foldDistance = 2,
       defaultPlotConfiguration = DPC
+    )
+  )
+})
+
+# Name mapping in legend
+
+test_that("Name mapping in legend can be controlled", {
+  # Create a test configuration with suppressNameInLegend set to FALSE
+  showNameConfig <- DefaultPlotConfiguration$new()
+  showNameConfig$suppressNameInLegend <- FALSE
+
+  # Create a test configuration with suppressNameInLegend set to TRUE (default)
+  hideNameConfig <- DefaultPlotConfiguration$new()
+  hideNameConfig$suppressNameInLegend <- TRUE
+
+  set.seed(123)
+
+  # Test with name visible in legend
+  vdiffr::expect_doppelganger(
+    title = "name shown in legend obs vs sim",
+    fig = plotObservedVsSimulated(
+      manyObsSimDC,
+      defaultPlotConfiguration = showNameConfig
+    )
+  )
+
+  # Test with name hidden in legend (default behavior)
+  vdiffr::expect_doppelganger(
+    title = "name hidden in legend obs vs sim",
+    fig = plotObservedVsSimulated(
+      manyObsSimDC,
+      defaultPlotConfiguration = hideNameConfig
     )
   )
 })

--- a/tests/testthat/test-plot-residuals-vs-simulated.R
+++ b/tests/testthat/test-plot-residuals-vs-simulated.R
@@ -2,9 +2,6 @@
 
 # plotResidualsVsSimulated")
 
-
-
-
 # load the simulation
 sim <- loadTestSimulation("MinimalModel")
 simResults <- importResultsFromCSV(
@@ -15,7 +12,9 @@ simResults <- importResultsFromCSV(
 # import observed data (will return a list of DataSet objects)
 dataSet <- loadDataSetsFromExcel(
   xlsFilePath = getTestDataFilePath("CompiledDataSetStevens2012.xlsx"),
-  importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath("ImporterConfiguration.xml"))
+  importerConfiguration = loadDataImporterConfiguration(getTestDataFilePath(
+    "ImporterConfiguration.xml"
+  ))
 )
 
 # create a new instance and add datasets
@@ -39,7 +38,14 @@ myCombDat$setGroups(
     "Stevens_2012_placebo.Placebo_distal",
     "Stevens_2012_placebo.Placebo_proximal"
   ),
-  groups = c("Solid total", "Solid distal", "Solid proximal", "Solid total", "Solid distal", "Solid proximal")
+  groups = c(
+    "Solid total",
+    "Solid distal",
+    "Solid proximal",
+    "Solid total",
+    "Solid distal",
+    "Solid proximal"
+  )
 )
 
 test_that("It creates default plots as expected", {
@@ -55,7 +61,10 @@ test_that("It doesn't work with log scale for Y-axis", {
   myPlotConfiguration <- DefaultPlotConfiguration$new()
   myPlotConfiguration$yAxisScale <- tlf::Scaling$log
   expect_error(
-    plotResidualsVsSimulated(myCombDat, defaultPlotConfiguration = myPlotConfiguration),
+    plotResidualsVsSimulated(
+      myCombDat,
+      defaultPlotConfiguration = myPlotConfiguration
+    ),
     messages$logScaleNotAllowed()
   )
 })
@@ -95,21 +104,32 @@ test_that("It respects custom plot configuration", {
 # edge cases ------------------------
 
 test_that("It doesn't extrapolate past maximum simulated time point", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simData <- withr::with_tempdir({
     df <- dplyr::tibble(
       IndividualId = c(0, 0, 0),
       `Time [min]` = c(0, 2, 4),
-      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(0, 4, 8)
+      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(
+        0,
+        4,
+        8
+      )
     )
     readr::write_csv(df, "SimResults.csv")
     importResultsFromCSV(sim, "SimResults.csv")
   })
 
   obsData <- DataSet$new(name = "Observed")
-  obsData$setValues(xValues = c(1, 3, 3.5, 4, 5), yValues = c(1.9, 6.1, 7, 8.2, 1))
+  obsData$setValues(
+    xValues = c(1, 3, 3.5, 4, 5),
+    yValues = c(1.9, 6.1, 7, 8.2, 1)
+  )
   obsData$xUnit <- "min"
 
   myDC <- DataCombined$new()
@@ -151,21 +171,32 @@ test_that("It returns `NULL` when `DataCombined` doesn't have any pairable datas
 })
 
 test_that("Different symbols for data sets within one group", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simData <- withr::with_tempdir({
     df <- dplyr::tibble(
       IndividualId = c(0, 0, 0),
       `Time [min]` = c(0, 2, 4),
-      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(0, 4, 8)
+      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(
+        0,
+        4,
+        8
+      )
     )
     readr::write_csv(df, "SimResults.csv")
     importResultsFromCSV(sim, "SimResults.csv")
   })
 
   obsData <- DataSet$new(name = "Observed")
-  obsData$setValues(xValues = c(1, 3, 3.5, 4, 5), yValues = c(1.9, 6.1, 7, 8.2, 1))
+  obsData$setValues(
+    xValues = c(1, 3, 3.5, 4, 5),
+    yValues = c(1.9, 6.1, 7, 8.2, 1)
+  )
   obsData$xUnit <- "min"
   obsData$yDimension <- ospDimensions$`Concentration (molar)`
 
@@ -175,7 +206,10 @@ test_that("Different symbols for data sets within one group", {
 
   # Add second obs data
   obsData2 <- DataSet$new(name = "Observed 2")
-  obsData2$setValues(xValues = c(0, 3, 4, 4.5, 5.5), yValues = c(2.9, 5.1, 3, 8.2, 1))
+  obsData2$setValues(
+    xValues = c(0, 3, 4, 4.5, 5.5),
+    yValues = c(2.9, 5.1, 3, 8.2, 1)
+  )
   obsData2$xUnit <- "min"
   obsData2$yDimension <- ospDimensions$`Concentration (molar)`
   myDC$addDataSets(obsData2, groups = "myGroup")
@@ -192,5 +226,37 @@ test_that("scaling residuals argument works with log", {
   vdiffr::expect_doppelganger(
     title = "log-residuals",
     fig = plotResidualsVsSimulated(myCombDat, scaling = "log")
+  )
+})
+
+# Name mapping in legend
+
+test_that("Name mapping in legend can be controlled", {
+  # Create a test configuration with suppressNameInLegend set to FALSE
+  showNameConfig <- DefaultPlotConfiguration$new()
+  showNameConfig$suppressNameInLegend <- FALSE
+
+  # Create a test configuration with suppressNameInLegend set to TRUE (default)
+  hideNameConfig <- DefaultPlotConfiguration$new()
+  hideNameConfig$suppressNameInLegend <- TRUE
+
+  set.seed(123)
+
+  # Test with name visible in legend
+  vdiffr::expect_doppelganger(
+    title = "name shown in legend residuals vs simulated",
+    fig = plotResidualsVsSimulated(
+      manyObsSimDC,
+      defaultPlotConfiguration = showNameConfig
+    )
+  )
+
+  # Test with name hidden in legend (default behavior)
+  vdiffr::expect_doppelganger(
+    title = "name hidden in legend residuals vs simulated",
+    fig = plotResidualsVsSimulated(
+      manyObsSimDC,
+      defaultPlotConfiguration = hideNameConfig
+    )
   )
 })

--- a/tests/testthat/test-plot-residuals-vs-time.R
+++ b/tests/testthat/test-plot-residuals-vs-time.R
@@ -2,9 +2,6 @@
 
 # plotResidualsVsTime
 
-
-
-
 # load the simulation
 sim <- loadTestSimulation("MinimalModel")
 simResults <- importResultsFromCSV(
@@ -15,7 +12,9 @@ simResults <- importResultsFromCSV(
 # import observed data (will return a list of DataSet objects)
 dataSet <- loadDataSetsFromExcel(
   xlsFilePath = getTestDataFilePath("CompiledDataSetStevens2012.xlsx"),
-  importerConfigurationOrPath = loadDataImporterConfiguration(getTestDataFilePath("ImporterConfiguration.xml"))
+  importerConfigurationOrPath = loadDataImporterConfiguration(getTestDataFilePath(
+    "ImporterConfiguration.xml"
+  ))
 )
 
 # create a new instance and add datasets
@@ -39,7 +38,14 @@ myCombDat$setGroups(
     "Stevens_2012_placebo.Placebo_distal",
     "Stevens_2012_placebo.Placebo_proximal"
   ),
-  groups = c("Solid total", "Solid distal", "Solid proximal", "Solid total", "Solid distal", "Solid proximal")
+  groups = c(
+    "Solid total",
+    "Solid distal",
+    "Solid proximal",
+    "Solid total",
+    "Solid distal",
+    "Solid proximal"
+  )
 )
 
 test_that("It creates default plots as expected", {
@@ -55,7 +61,10 @@ test_that("It doesn't work with log scale for Y-axis", {
   myPlotConfiguration <- DefaultPlotConfiguration$new()
   myPlotConfiguration$yAxisScale <- tlf::Scaling$log
   expect_error(
-    plotResidualsVsTime(myCombDat, defaultPlotConfiguration = myPlotConfiguration),
+    plotResidualsVsTime(
+      myCombDat,
+      defaultPlotConfiguration = myPlotConfiguration
+    ),
     messages$logScaleNotAllowed()
   )
 })
@@ -122,21 +131,32 @@ test_that("It returns `NULL` when `DataCombined` doesn't have any pairable datas
 })
 
 test_that("Different symbols for data sets within one group", {
-  simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  simFilePath <- system.file(
+    "extdata",
+    "Aciclovir.pkml",
+    package = "ospsuite"
+  )
   sim <- loadSimulation(simFilePath)
 
   simData <- withr::with_tempdir({
     df <- dplyr::tibble(
       IndividualId = c(0, 0, 0),
       `Time [min]` = c(0, 2, 4),
-      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(0, 4, 8)
+      `Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood) [µmol/l]` = c(
+        0,
+        4,
+        8
+      )
     )
     readr::write_csv(df, "SimResults.csv")
     importResultsFromCSV(sim, "SimResults.csv")
   })
 
   obsData <- DataSet$new(name = "Observed")
-  obsData$setValues(xValues = c(1, 3, 3.5, 4, 5), yValues = c(1.9, 6.1, 7, 8.2, 1))
+  obsData$setValues(
+    xValues = c(1, 3, 3.5, 4, 5),
+    yValues = c(1.9, 6.1, 7, 8.2, 1)
+  )
   obsData$xUnit <- "min"
   obsData$yDimension <- ospDimensions$`Concentration (molar)`
 
@@ -146,7 +166,10 @@ test_that("Different symbols for data sets within one group", {
 
   # Add second obs data
   obsData2 <- DataSet$new(name = "Observed 2")
-  obsData2$setValues(xValues = c(0, 3, 4, 4.5, 5.5), yValues = c(2.9, 5.1, 3, 8.2, 1))
+  obsData2$setValues(
+    xValues = c(0, 3, 4, 4.5, 5.5),
+    yValues = c(2.9, 5.1, 3, 8.2, 1)
+  )
   obsData2$xUnit <- "min"
   obsData2$yDimension <- ospDimensions$`Concentration (molar)`
   myDC$addDataSets(obsData2, groups = "myGroup")
@@ -163,5 +186,37 @@ test_that("scaling residuals argument works with log", {
   vdiffr::expect_doppelganger(
     title = "log-residuals",
     fig = plotResidualsVsTime(myCombDat, scaling = "log")
+  )
+})
+
+# Name mapping in legend
+
+test_that("Name mapping in legend can be controlled", {
+  # Create a test configuration with suppressNameInLegend set to FALSE
+  showNameConfig <- DefaultPlotConfiguration$new()
+  showNameConfig$suppressNameInLegend <- FALSE
+
+  # Create a test configuration with suppressNameInLegend set to TRUE (default)
+  hideNameConfig <- DefaultPlotConfiguration$new()
+  hideNameConfig$suppressNameInLegend <- TRUE
+
+  set.seed(123)
+
+  # Test with name visible in legend
+  vdiffr::expect_doppelganger(
+    title = "name shown in legend residuals vs time",
+    fig = plotResidualsVsTime(
+      manyObsSimDC,
+      defaultPlotConfiguration = showNameConfig
+    )
+  )
+
+  # Test with name hidden in legend (default behavior)
+  vdiffr::expect_doppelganger(
+    title = "name hidden in legend residuals vs time",
+    fig = plotResidualsVsTime(
+      manyObsSimDC,
+      defaultPlotConfiguration = hideNameConfig
+    )
   )
 })


### PR DESCRIPTION
- Introduced `suppressNameInLegend` field in `DefaultPlotConfiguration` to control name mapping in legends.
- Updated relevant plotting functions to respect the new configuration option.
- Enhanced tests to verify the behavior of the `suppressNameInLegend` setting in various plot scenarios.