### PR TITLE
Update personal website link to new domain

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,7 +20,7 @@ authors:
   Felix Mil:
     href: https://github.com/Felixmil
   Indrajeet Patil:
-    href: https://sites.google.com/site/indrajeetspatilmorality/
+    href: https://indrajeetpatil.github.io/
 
 articles:
 


### PR DESCRIPTION
The author's personal website has moved from the old Google Sites domain to a new domain.

This updates the author link in `_pkgdown.yml` accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated author profile link in documentation configuration to direct to the author's personal website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->