### PR TITLE
Use clone accessors for DC/DPC test fixtures

### DIFF
--- a/tests/data/create_data_combined_objects.R
+++ b/tests/data/create_data_combined_objects.R
@@ -26,102 +26,113 @@ obsData <- lapply(
 names(obsData) <- lapply(obsData, function(x) x$name)
 
 # `DataCombined` (DC) objects ----------------------------
+# Each object is stored with a `.` prefix and exposed via an accessor function
+# that returns a fresh clone, so tests can safely mutate the returned object.
 
 ## only one observed dataset ------------------------
 
-oneObsDCGlobal <- DataCombined$new()
-oneObsDCGlobal$addDataSets(obsData$`Vergin 1995.Iv`)
+.oneObsDC <- DataCombined$new()
+.oneObsDC$addDataSets(obsData$`Vergin 1995.Iv`)
+oneObsDC <- function() .oneObsDC$clone(deep = TRUE)
 
 ## only one simulated dataset ------------------------
 
-oneSimDCGlobal <- DataCombined$new()
-oneSimDCGlobal$addSimulationResults(
+.oneSimDC <- DataCombined$new()
+.oneSimDC$addSimulationResults(
   simulationResults = simResults,
   quantitiesOrPaths = outputPathSingle,
   groups = "Aciclovir PVB"
 )
+oneSimDC <- function() .oneSimDC$clone(deep = TRUE)
 
 ## many observed datasets ------------------------
 
-manyObsDCGlobal <- DataCombined$new()
-manyObsDCGlobal$addDataSets(
+.manyObsDC <- DataCombined$new()
+.manyObsDC$addDataSets(
   c(obsData$`Vergin 1995.Iv`, obsData$`Laskin 1982.Group C`),
   groups = "Aciclovir observed"
 )
+manyObsDC <- function() .manyObsDC$clone(deep = TRUE)
 
 ## many simulated datasets ------------------------
 
-manySimDCGlobal <- DataCombined$new()
-manySimDCGlobal$addSimulationResults(
+.manySimDC <- DataCombined$new()
+.manySimDC$addSimulationResults(
   simulationResults = simResults,
   # Excluding the fraction excreted output
   quantitiesOrPaths = outputPaths[1:2],
   groups = "Aciclovir PVB"
 )
+manySimDC <- function() .manySimDC$clone(deep = TRUE)
 
 ## one observed and one simulated dataset ------------------------
 
-oneObsSimDCGlobal <- DataCombined$new()
-oneObsSimDCGlobal$addDataSets(
+.oneObsSimDC <- DataCombined$new()
+.oneObsSimDC$addDataSets(
   obsData$`Vergin 1995.Iv`,
   groups = "Aciclovir PVB"
 )
-oneObsSimDCGlobal$addSimulationResults(
+.oneObsSimDC$addSimulationResults(
   simulationResults = simResults,
   quantitiesOrPaths = outputPathSingle,
   groups = "Aciclovir PVB"
 )
+oneObsSimDC <- function() .oneObsSimDC$clone(deep = TRUE)
 
 ## multiple observed and multiple simulated datasets ------------------------
 
-manyObsSimDCGlobal <- DataCombined$new()
-manyObsSimDCGlobal$addDataSets(
+.manyObsSimDC <- DataCombined$new()
+.manyObsSimDC$addDataSets(
   c(obsData$`Vergin 1995.Iv`, obsData$`Laskin 1982.Group C`),
   groups = "Aciclovir observed"
 )
-manyObsSimDCGlobal$addSimulationResults(
+.manyObsSimDC$addSimulationResults(
   simulationResults = simResults,
   # Excluding the fraction excreted output
   quantitiesOrPaths = outputPaths[1:2],
   groups = "Aciclovir PVB"
 )
+manyObsSimDC <- function() .manyObsSimDC$clone(deep = TRUE)
 
 ## dataset with geometric error ------------------------
 
-oneObsGeometricDCGlobal <- DataCombined$new()
-oneObsGeometricDCGlobal$addDataSets(
+.oneObsGeometricDC <- DataCombined$new()
+.oneObsGeometricDC$addDataSets(
   obsData$`Laskin 1982.Group C`,
   groups = "Aciclovir PVB"
 )
+oneObsGeometricDC <- function() .oneObsGeometricDC$clone(deep = TRUE)
 
 # custom default plot configuration (DPC) -------------------------------------
 
-customDPCGlobal <- DefaultPlotConfiguration$new()
-customDPCGlobal$title <- "My Plot Title"
-customDPCGlobal$subtitle <- "My Plot Subtitle"
-customDPCGlobal$caption <- "My Sources"
-customDPCGlobal$legendPosition <- tlf::LegendPositions$outsideRight
-customDPCGlobal$yAxisScale <- "log"
-customDPCGlobal$yAxisLimits <- c(0.01, 1000)
+.customDPC <- DefaultPlotConfiguration$new()
+.customDPC$title <- "My Plot Title"
+.customDPC$subtitle <- "My Plot Subtitle"
+.customDPC$caption <- "My Sources"
+.customDPC$legendPosition <- tlf::LegendPositions$outsideRight
+.customDPC$yAxisScale <- "log"
+.customDPC$yAxisLimits <- c(0.01, 1000)
+customDPC <- function() .customDPC$clone(deep = TRUE)
 
 # dataset with mixed dimensions and y-Units ---------------------------
 
-manyObsSimDCWithFractionGlobal <- DataCombined$new()
+.manyObsSimDCWithFraction <- DataCombined$new()
 
-manyObsSimDCWithFractionGlobal$addSimulationResults(
+.manyObsSimDCWithFraction$addSimulationResults(
   simulationResults = simResults,
   quantitiesOrPaths = outputPaths[[1]],
   names = "Aciclovir Plasma",
   groups = "Aciclovir PVB"
 )
-manyObsSimDCWithFractionGlobal$addSimulationResults(
+.manyObsSimDCWithFraction$addSimulationResults(
   simulationResults = simResults,
   quantitiesOrPaths = outputPaths[[3]],
   names = "Aciclovir Fraction excreted",
   groups = "Aciclovir Urine"
 )
 
-manyObsSimDCWithFractionGlobal$addDataSets(
+.manyObsSimDCWithFraction$addDataSets(
   obsData[[1]],
   groups = "Aciclovir PVB"
 )
+manyObsSimDCWithFraction <- function() .manyObsSimDCWithFraction$clone(deep = TRUE)

--- a/tests/testthat/test-1-deprecation-tlf-functions.R
+++ b/tests/testthat/test-1-deprecation-tlf-functions.R
@@ -4,7 +4,7 @@
 
 test_that("plotIndividualTimeProfile emits a soft deprecation warning pointing to plotTimeProfile", {
   expect_warning(
-    plotIndividualTimeProfile(oneObsDCGlobal),
+    plotIndividualTimeProfile(oneObsDC()),
     regexp = "plotIndividualTimeProfile.*deprecated.*plotTimeProfile",
     class = "lifecycle_warning_deprecated"
   )
@@ -14,7 +14,7 @@ test_that("plotIndividualTimeProfile emits a soft deprecation warning pointing t
 
 test_that("plotPopulationTimeProfile emits a soft deprecation warning pointing to plotTimeProfile", {
   expect_warning(
-    plotPopulationTimeProfile(oneObsDCGlobal),
+    plotPopulationTimeProfile(oneObsDC()),
     regexp = "plotPopulationTimeProfile.*deprecated.*plotTimeProfile",
     class = "lifecycle_warning_deprecated"
   )

--- a/tests/testthat/test-1-plot-individual-time-profile.R
+++ b/tests/testthat/test-1-plot-individual-time-profile.R
@@ -6,7 +6,7 @@ test_that("It creates default plots as expected for single observed dataset", {
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "single obs",
-    fig = plotIndividualTimeProfile(oneObsDCGlobal)
+    fig = plotIndividualTimeProfile(oneObsDC())
   )
 })
 
@@ -14,7 +14,7 @@ test_that("It creates default plots as expected for multiple observed datasets",
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "multiple obs",
-    fig = plotIndividualTimeProfile(manyObsDCGlobal)
+    fig = plotIndividualTimeProfile(manyObsDC())
   )
 })
 
@@ -23,7 +23,7 @@ test_that("It plots multiple observed datasets with dataset name legend entries"
   vdiffr::expect_doppelganger(
     title = "multiple obs - separate legend",
     fig = plotIndividualTimeProfile(
-      manyObsDCGlobal,
+      manyObsDC(),
       showLegendPerDataset = TRUE
     )
   )
@@ -36,7 +36,7 @@ test_that("It creates default plots as expected for single simulated dataset", {
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "single sim",
-    fig = plotIndividualTimeProfile(oneSimDCGlobal)
+    fig = plotIndividualTimeProfile(oneSimDC())
   )
 })
 
@@ -44,7 +44,7 @@ test_that("It creates default plots as expected for multiple simulated datasets"
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "multiple sim",
-    fig = plotIndividualTimeProfile(manySimDCGlobal)
+    fig = plotIndividualTimeProfile(manySimDC())
   )
 })
 
@@ -53,7 +53,7 @@ test_that("It plots multiple simulated datasets with dataset name legend entries
   vdiffr::expect_doppelganger(
     title = "multiple sim - separate legend",
     fig = plotIndividualTimeProfile(
-      manySimDCGlobal,
+      manySimDC(),
       showLegendPerDataset = TRUE
     )
   )
@@ -65,7 +65,7 @@ test_that("It creates default plots as expected for both observed and simulated"
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "both - default",
-    fig = plotIndividualTimeProfile(oneObsSimDCGlobal)
+    fig = plotIndividualTimeProfile(oneObsSimDC())
   )
 })
 
@@ -73,13 +73,13 @@ test_that("It respects custom plot configuration", {
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "both - custom",
-    fig = plotIndividualTimeProfile(oneObsSimDCGlobal, customDPCGlobal)
+    fig = plotIndividualTimeProfile(oneObsSimDC(), customDPC())
   )
 
   # Since these were not specified by the user, they should not be updated
   # after plotting function is done with it.
-  expect_null(customDPCGlobal$xLabel)
-  expect_null(customDPCGlobal$yLabel)
+  expect_null(customDPC()$xLabel)
+  expect_null(customDPC()$yLabel)
 })
 
 test_that("It plots both observed and simulated datasets with dataset name legend entries", {
@@ -87,7 +87,7 @@ test_that("It plots both observed and simulated datasets with dataset name legen
   vdiffr::expect_doppelganger(
     title = "both - separate legend",
     fig = plotIndividualTimeProfile(
-      oneObsSimDCGlobal,
+      oneObsSimDC(),
       showLegendPerDataset = TRUE
     )
   )
@@ -98,8 +98,8 @@ test_that("It plots both observed and simulated datasets with dataset name legen
   vdiffr::expect_doppelganger(
     title = "both - custom - separate legend",
     fig = plotIndividualTimeProfile(
-      oneObsSimDCGlobal,
-      customDPCGlobal,
+      oneObsSimDC(),
+      customDPC(),
       showLegendPerDataset = TRUE
     )
   )
@@ -111,7 +111,7 @@ test_that("It maps multiple observed and simulated datasets to different visual 
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "multiple obs and sim",
-    fig = plotIndividualTimeProfile(manyObsSimDCGlobal)
+    fig = plotIndividualTimeProfile(manyObsSimDC())
   )
 })
 
@@ -121,7 +121,7 @@ test_that("It works when geometric error is present", {
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "geometric error",
-    fig = plotIndividualTimeProfile(oneObsGeometricDCGlobal)
+    fig = plotIndividualTimeProfile(oneObsGeometricDC())
   )
 })
 

--- a/tests/testthat/test-1-plot-with-ospsuite-plots-PredictedVsObserved.R
+++ b/tests/testthat/test-1-plot-with-ospsuite-plots-PredictedVsObserved.R
@@ -245,7 +245,7 @@ test_that("It swaps axes when predictedAxis is 'x'", {
 # 2 y-axis dimensions ----
 test_that("Plot throws error with fraction and concentration", {
   expect_error(
-    plotPredictedVsObserved(manyObsSimDCWithFractionGlobal),
+    plotPredictedVsObserved(manyObsSimDCWithFraction()),
     'Data contains too many'
   )
 })

--- a/tests/testthat/test-1-plot-with-ospsuite-plots-individualTimeProfiles.R
+++ b/tests/testthat/test-1-plot-with-ospsuite-plots-individualTimeProfiles.R
@@ -11,7 +11,7 @@ test_that("It creates default plots as expected for single observed dataset", {
 
   vdiffr::expect_doppelganger(
     title = "single obs",
-    fig = plotTimeProfile(oneObsDCGlobal)
+    fig = plotTimeProfile(oneObsDC())
   )
 })
 
@@ -20,25 +20,25 @@ test_that("It creates default plots as expected for multiple observed datasets",
 
   vdiffr::expect_doppelganger(
     title = "multiple obs",
-    fig = plotTimeProfile(manyObsDCGlobal)
+    fig = plotTimeProfile(manyObsDC())
   )
 
   vdiffr::expect_doppelganger(
     title = "multiple obs - separate legend",
     fig = plotTimeProfile(
-      manyObsDCGlobal,
+      manyObsDC(),
       mapping = ggplot2::aes(groupby = name)
     )
   )
 
   vdiffr::expect_doppelganger(
     title = "multiple obs - showLegendPerDataset none",
-    fig = plotTimeProfile(manyObsDCGlobal, showLegendPerDataset = "none")
+    fig = plotTimeProfile(manyObsDC(), showLegendPerDataset = "none")
   )
 
   vdiffr::expect_doppelganger(
     title = "multiple obs - showLegendPerDataset observed",
-    fig = plotTimeProfile(manyObsDCGlobal, showLegendPerDataset = "observed")
+    fig = plotTimeProfile(manyObsDC(), showLegendPerDataset = "observed")
   )
 })
 
@@ -48,7 +48,7 @@ test_that("It creates default plots as expected for single simulated dataset", {
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "single sim",
-    fig = plotTimeProfile(oneSimDCGlobal)
+    fig = plotTimeProfile(oneSimDC())
   )
 })
 
@@ -57,7 +57,7 @@ test_that("It plots multiple simulated datasets with dataset name legend entries
   vdiffr::expect_doppelganger(
     title = "multiple sim - separate legend",
     fig = plotTimeProfile(
-      manySimDCGlobal,
+      manySimDC(),
       mapping = ggplot2::aes(
         group = name,
         linetype = name
@@ -67,12 +67,12 @@ test_that("It plots multiple simulated datasets with dataset name legend entries
 
   vdiffr::expect_doppelganger(
     title = "multiple sim - showLegendPerDataset none",
-    fig = plotTimeProfile(manySimDCGlobal, showLegendPerDataset = "none")
+    fig = plotTimeProfile(manySimDC(), showLegendPerDataset = "none")
   )
 
   vdiffr::expect_doppelganger(
     title = "multiple sim - showLegendPerDataset simulated",
-    fig = plotTimeProfile(manySimDCGlobal, showLegendPerDataset = "simulated")
+    fig = plotTimeProfile(manySimDC(), showLegendPerDataset = "simulated")
   )
 })
 
@@ -82,7 +82,7 @@ test_that("It creates default plots as expected for both observed and simulated"
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "both - default",
-    fig = plotTimeProfile(oneObsSimDCGlobal)
+    fig = plotTimeProfile(oneObsSimDC())
   )
 })
 
@@ -92,7 +92,7 @@ test_that("It creates default plot with group legend for multiple obs and sim", 
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "many obs sim - default",
-    fig = plotTimeProfile(manyObsSimDCGlobal)
+    fig = plotTimeProfile(manyObsSimDC())
   )
 })
 
@@ -101,7 +101,7 @@ test_that("It maps multiple observed and simulated datasets to different visual 
   vdiffr::expect_doppelganger(
     title = "many obs sim - name",
     fig = plotTimeProfile(
-      manyObsSimDCGlobal,
+      manyObsSimDC(),
       mapping = ggplot2::aes(linetype = name),
       observedMapping = ggplot2::aes(fill = name)
     )
@@ -109,13 +109,13 @@ test_that("It maps multiple observed and simulated datasets to different visual 
 
   vdiffr::expect_doppelganger(
     title = "many obs sim - showLegendPerDataset none",
-    fig = plotTimeProfile(manyObsSimDCGlobal, showLegendPerDataset = "none")
+    fig = plotTimeProfile(manyObsSimDC(), showLegendPerDataset = "none")
   )
 
   vdiffr::expect_doppelganger(
     title = "many obs sim - showLegendPerDataset observed",
     fig = plotTimeProfile(
-      manyObsSimDCGlobal,
+      manyObsSimDC(),
       showLegendPerDataset = "observed"
     )
   )
@@ -123,7 +123,7 @@ test_that("It maps multiple observed and simulated datasets to different visual 
   vdiffr::expect_doppelganger(
     title = "many obs sim - showLegendPerDataset simulated",
     fig = plotTimeProfile(
-      manyObsSimDCGlobal,
+      manyObsSimDC(),
       showLegendPerDataset = "simulated"
     )
   )
@@ -134,7 +134,7 @@ test_that("It applies yScale and yScaleArgs to multiple obs and sim datasets", {
   vdiffr::expect_doppelganger(
     title = "many obs sim - log scale",
     fig = plotTimeProfile(
-      manyObsSimDCGlobal,
+      manyObsSimDC(),
       yScale = "log",
       yScaleArgs = list(limits = c(0.001, NA))
     )
@@ -147,7 +147,7 @@ test_that("User-provided mappings override showLegendPerDataset", {
   vdiffr::expect_doppelganger(
     title = "user mapping overrides showLegendPerDataset",
     fig = plotTimeProfile(
-      manyObsSimDCGlobal,
+      manyObsSimDC(),
       showLegendPerDataset = "all",
       mapping = ggplot2::aes(color = name, linetype = NULL),
       observedMapping = ggplot2::aes(
@@ -164,13 +164,13 @@ test_that("User-provided mappings override showLegendPerDataset", {
 test_that("It warns when showLegendPerDataset setting doesn't match data", {
   # Only observed data, but asking for simulated differentiation
   expect_warning(
-    plotTimeProfile(manyObsDCGlobal, showLegendPerDataset = "simulated"),
+    plotTimeProfile(manyObsDC(), showLegendPerDataset = "simulated"),
     "showLegendPerDataset = 'simulated' but no simulated data present"
   )
 
   # Only simulated data, but asking for observed differentiation
   expect_warning(
-    plotTimeProfile(manySimDCGlobal, showLegendPerDataset = "observed"),
+    plotTimeProfile(manySimDC(), showLegendPerDataset = "observed"),
     "showLegendPerDataset = 'observed' but no observed data present"
   )
 })
@@ -179,7 +179,7 @@ test_that("It warns when user mapping contains untypical aesthetics", {
   # User shape is unusual for simulated
   expect_warning(
     plotTimeProfile(
-      manySimDCGlobal,
+      manySimDC(),
       mapping = ggplot2::aes(shape = dataType)
     ),
     messages$plotUntypicalAesthetic(
@@ -191,7 +191,7 @@ test_that("It warns when user mapping contains untypical aesthetics", {
   # User shape is unusual for simulated
   expect_warning(
     plotTimeProfile(
-      manyObsDCGlobal,
+      manyObsDC(),
       observedMapping = ggplot2::aes(linetype = dataType)
     ),
     messages$plotUntypicalAesthetic(
@@ -204,7 +204,7 @@ test_that("It warns when user mapping contains untypical aesthetics", {
 test_that("line width does not leak into observedMapping", {
   expect_no_warning(
     plotTimeProfile(
-      manyObsSimDCGlobal,
+      manyObsSimDC(),
       mapping = ggplot2::aes(linetype = name)
     )
   )
@@ -216,7 +216,7 @@ test_that("It works when geometric error is present", {
   set.seed(123)
   vdiffr::expect_doppelganger(
     title = "geometric error",
-    fig = plotTimeProfile(oneObsGeometricDCGlobal)
+    fig = plotTimeProfile(oneObsGeometricDC())
   )
 })
 
@@ -255,7 +255,7 @@ test_that("It plots LLOQ correctly on log scale", {
 test_that("It plots data with two y-axis dimensions (fraction and concentration)", {
   vdiffr::expect_doppelganger(
     title = "with_secAxis",
-    fig = plotTimeProfile(manyObsSimDCWithFractionGlobal, yScale = "log") +
+    fig = plotTimeProfile(manyObsSimDCWithFraction(), yScale = "log") +
       ggplot2::theme(
         legend.position = c(0.95, 0.05),
         legend.justification = c("right", "bottom")
@@ -267,10 +267,10 @@ test_that("It plots data with two y-axis dimensions (fraction and concentration)
 
 test_that("It converts x-axis units when xUnit is provided", {
   # Default: x in h; override to "min"
-  plotDefault <- plotTimeProfile(oneObsDCGlobal)
+  plotDefault <- plotTimeProfile(oneObsDC())
 
   plotMinutes <-
-    plotTimeProfile(oneObsDCGlobal, xUnit = "min")
+    plotTimeProfile(oneObsDC(), xUnit = "min")
 
   # The x-axis label should contain "min" when xUnit = "min"
   expect_true(
@@ -288,7 +288,7 @@ test_that("It converts y-axis units when yUnit is provided", {
   # most frequent units would be xUnit 'h',yUnit 'mg/l', y2Unit = ''
   # overwrite this with userdefined units
   plotNonDefaultUnits <- plotTimeProfile(
-    manyObsSimDCWithFractionGlobal,
+    manyObsSimDCWithFraction(),
     xUnit = 'day(s)',
     yUnit = 'ng/l',
     y2Unit = '%'
@@ -304,12 +304,12 @@ test_that("It converts y-axis units when yUnit is provided", {
 test_that("It produces the same result as pre-converting with convertUnits", {
   # Passing units directly should be equivalent to calling convertUnits first
   plotDirect <- plotTimeProfile(
-    oneObsSimDCGlobal,
+    oneObsSimDC(),
     xUnit = "day(s)",
     yUnit = 'mg/l'
   )
   plotPreConverted <- plotTimeProfile(convertUnits(
-    oneObsSimDCGlobal,
+    oneObsSimDC(),
     yUnit = 'mg/l',
     xUnit = "day(s)"
   ))
@@ -317,7 +317,7 @@ test_that("It produces the same result as pre-converting with convertUnits", {
   expect_equal(plotDirect$data, plotPreConverted$data)
 
   plotDataFrame <- plotTimeProfile(
-    oneObsSimDCGlobal$toDataFrame(),
+    oneObsSimDC()$toDataFrame(),
     xUnit = "day(s)",
     yUnit = 'mg/l'
   )


### PR DESCRIPTION
## Summary

- Stores each canonical `DataCombined` / `DefaultPlotConfiguration` fixture with a `.` prefix in `create_data_combined_objects.R`
- Exposes each via an accessor function (e.g. `oneObsDC()`) that returns a fresh `$clone(deep = TRUE)` on every call
- Updates all test call sites from bare variable to function call syntax

This makes mutation-safety foolproof: tests receive an independent copy each time, so accidental mutation cannot affect other tests or other workers.