### PR TITLE
Fix version bump condition to only trigger on push to main

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -10,7 +10,7 @@ permissions: write-all
 
 jobs:
   bump-dev-version: # only do that when actually merging in main/develop branch
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump_dev_version_tag_branch.yaml@main
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}


### PR DESCRIPTION
## Summary
- Change bump-dev-version job condition from `!= 'pull_request'` to explicit `push && refs/heads/main`
- Prevents unintended version bumps on workflow_dispatch