### PR TITLE
Use Posit Package Manager only (not CRAN)

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -5,10 +5,6 @@
       {
         "Name": "PPM",
         "URL": "https://packagemanager.posit.co/cran/latest"
-      },
-      {
-        "Name": "CRAN",
-        "URL": "https://cran.rstudio.com"
       }
     ]
   },


### PR DESCRIPTION
Because PPM always have source and binary packages aligned, this is not the case of CRAN. On CRAN, source is immediately available upon package version validation, but builds won’t be available until later.

This can cause our renv updating workflow to fail because the first runner (Linux) will find the new version (source), but the macOS and Windows runners won’t find any builds for that version.

Here’s an example:

<img width="1082" height="558" alt="image" src="https://github.com/user-attachments/assets/f7c0f21f-7c51-4a48-9db2-22c71a973932" />

Since many packages are updated each day, by the time a package gets its binaries, another package has been updated and has different source/binary versions.