### PR TITLE
Move showtext from Imports to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Imports:
     lifecycle,
     cli,
     rSharp,
-    showtext,
     checkmate
 Suggests:
     pacman,
@@ -46,6 +45,7 @@ Suggests:
     testthat (>= 3.0.3),
     vdiffr (>= 1.0.0),
     withr,
+    showtext,
     sysfonts,
     devtools (>= 2.4.5),
     diffviewer


### PR DESCRIPTION
## Summary

Moves `showtext` from `Imports:` to `Suggests:` in `DESCRIPTION` (next to `sysfonts`, which has been in `Suggests:` since 2023).

## Why

`showtext` is not used anywhere in ospsuite's R code, tests, or `inst/`. Its only role is the `fig.showtext = TRUE` knitr chunk option in 15 vignettes — a build-time dependency, which is exactly what `Suggests:` is for.

`R CMD check`, `devtools::check()`, `install.packages()` (default `dependencies = NA`), and `remotes`/`devtools::install_github()` all install Suggests of the target package by default, so vignette builds are unaffected on those paths.

## History

Originally added to `Suggests:` by @PavelBal in commit 6681165c (April 2023), alongside `sysfonts`.

Promoted to `Imports:` in #1484 (commit 5ffa7660, Sept 2024) to address #1409, which reported that vignettes couldn't be built when installing from GitHub because `showtext` wasn't auto-installed.

That fix addressed a real annoyance but in the wrong place:

- `Imports:` forces `showtext` (and its system font deps like FreeType) on every ospsuite user, including headless / server / minimal-container users who never build vignettes.
- The original "vignettes don't build out of the box" complaint is actually handled by `Suggests:` for almost every installer (`install.packages()`, `remotes::install_github()`, `devtools::install_github()` all install Suggests of the target by default).
- The one remaining gap is `pak::pak()`, which skips Suggests by default — users on pak need `dependencies = TRUE`.

## Long-term fix (out of scope here)

`showtext` and `sysfonts` are actually runtime dependencies of [`tlf`](https://github.com/Open-Systems-Pharmacology/TLF-Library) (used in `R/zzz.R`, `R/font.R`, `R/utilities-ggplot.R`, `R/plotconfiguration-export.R`, all gated behind `requireNamespace()`). Moving them to `Imports:` in tlf and dropping the guards would let ospsuite drop `showtext` from its DESCRIPTION entirely and survive any installer's defaults. To be tracked separately.

Closes #1409 (revisits and supersedes the fix from #1484).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Showtext package is now an optional dependency. This allows for a more lightweight installation for users who don't require showtext functionality, while maintaining full capability for those who do. No breaking changes to existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->