### PR TITLE
[smoke test] Point at Workflows#226 branch

### DIFF
--- a/.github/workflows/R-CMD-check-released-deps.yaml
+++ b/.github/workflows/R-CMD-check-released-deps.yaml
@@ -9,5 +9,5 @@ permissions: read-all
 
 jobs:
   check-released-deps:
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-released-deps.yaml@main
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-released-deps.yaml@use-org-runner-var-test-csharp
     secrets: inherit

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -11,7 +11,7 @@ permissions: write-all
 jobs:
   bump-dev-version: # only do that when actually merging in main/develop branch
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump_dev_version_tag_branch.yaml@main
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump_dev_version_tag_branch.yaml@use-org-runner-var-test-csharp
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:
@@ -20,16 +20,16 @@ jobs:
   R-CMD-Check:
     if: ${{ !cancelled() }}
     needs: [bump-dev-version]
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@use-org-runner-var-test-csharp
 
   test-coverage:
     if: ${{ !cancelled() }}
     needs: [bump-dev-version]
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@use-org-runner-var-test-csharp
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pkgdown:
     if: ${{ !cancelled() }}
     needs: [bump-dev-version]
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@use-org-runner-var-test-csharp

--- a/.github/workflows/update-renv-nightly.yaml
+++ b/.github/workflows/update-renv-nightly.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update-renv-nightly:
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/update-renv-lockfile.yaml@main
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/update-renv-lockfile.yaml@use-org-runner-var-test-csharp
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:


### PR DESCRIPTION
## Purpose

**Do not merge.** Smoke-test PR for [Open-systems-pharmacology/Workflows#226](https://github.com/Open-Systems-Pharmacology/Workflows/pull/226), which switches every reusable-workflow runner to `\${{ vars.GHA_DEFAULT_RUNNER_<OS> || '<os>-latest' }}` and substitutes the same expression into the `os-matrix` JSON-array defaults of the matrix-driven workflows.

## What this PR does
- Pins all six `uses:` references to `Workflows/.github/workflows/...` from `@main` to `@use-org-runner-var-test-csharp` in this repo's three workflow files.
- That covers both code paths in #226:
  - **Plain `runs-on:` substitution** — exercised by `bump_dev_version_tag_branch`, `test-coverage`, `pkgdown`, `R-CMD-check-released-deps`.
  - **JSON-array `os-matrix` default substitution** (the one not officially documented to support `vars`) — exercised by `R-CMD-check-build` and `update-renv-lockfile`.

## What success looks like
- All jobs schedule onto a runner without YAML/expression errors.
- Without org variables set: each job lands on the literal `<os>-latest` runner. Confirms the fallback path works and `vars` evaluates cleanly inside input defaults.
- With `GHA_DEFAULT_RUNNER_*` set at org or repo level: each job lands on the org-defined runner.

After verification this branch should be deleted, not merged.