### PR TITLE
Fixes #1948 use assembly-qualified type names in rSharp::callStatic

### DIFF
--- a/R/data-column.R
+++ b/R/data-column.R
@@ -1,5 +1,5 @@
-WITH_DIMENSION_EXTENSION <- "OSPSuite.Core.Domain.WithDimensionExtensions"
-WITH_DISPLAY_UNIT_EXTENSION <- "OSPSuite.Core.Domain.WithDisplayUnitExtensions"
+WITH_DIMENSION_EXTENSION <- "OSPSuite.Core.Domain.WithDimensionExtensions, OSPSuite.Core"
+WITH_DISPLAY_UNIT_EXTENSION <- "OSPSuite.Core.Domain.WithDisplayUnitExtensions, OSPSuite.Core"
 
 #' @title DataColumn
 #' @docType class

--- a/R/entity.R
+++ b/R/entity.R
@@ -1,4 +1,4 @@
-EntityExtensions <- "OSPSuite.Core.Domain.EntityExtensions"
+EntityExtensions <- "OSPSuite.Core.Domain.EntityExtensions, OSPSuite.Core"
 
 #' @title Entity
 #' @docType class

--- a/R/formula.R
+++ b/R/formula.R
@@ -1,4 +1,4 @@
-FormulaExtensions <- "OSPSuite.Core.Domain.Formulas.FormulaExtensions"
+FormulaExtensions <- "OSPSuite.Core.Domain.Formulas.FormulaExtensions, OSPSuite.Core"
 
 #' @title Formula
 #' @docType class

--- a/R/get-net-task.R
+++ b/R/get-net-task.R
@@ -7,7 +7,7 @@
 #'
 #' @keywords internal
 .getCoreTask <- function(taskName) {
-  rSharp::callStatic("OSPSuite.R.Api", paste0("Get", taskName))
+  rSharp::callStatic("OSPSuite.R.Api, OSPSuite.R", paste0("Get", taskName))
 }
 
 #' @title .getMoBiTask
@@ -19,7 +19,7 @@
 #'
 #' @keywords internal
 .getMoBiTask <- function(taskName) {
-  rSharp::callStatic("MoBi.R.Api", paste0("Get", taskName))
+  rSharp::callStatic("MoBi.R.Api, MoBi.R", paste0("Get", taskName))
 }
 
 #' @title .getCoreTaskFromCache

--- a/R/init-package.R
+++ b/R/init-package.R
@@ -58,7 +58,7 @@
   mobiR <- system.file("lib", "MoBi.R.dll", package = ospsuiteEnv$packageName)
 
   rSharp::loadAssembly(mobiR)
-  rSharp::callStatic("MoBi.R.Api", "InitializeOnce", apiConfig)
+  rSharp::callStatic("MoBi.R.Api, MoBi.R", "InitializeOnce", apiConfig)
 
   .initializeDimensionAndUnitLists()
   .loadEnums()
@@ -93,12 +93,12 @@
 #' @keywords internal
 .loadMoleculeTypeEnum <- function() {
   quantityType <- rSharp::getType("OSPSuite.Core.Domain.QuantityType")
-  netValues <- rSharp::callStatic("System.Enum", "GetValues", quantityType)
+  netValues <- rSharp::callStatic("System.Enum, System.Runtime", "GetValues", quantityType)
   flagByName <- list()
   for (netValue in netValues) {
     name <- netValue$call("ToString")
     flagByName[[name]] <- as.integer(rSharp::callStatic(
-      "System.Convert",
+      "System.Convert, System.Runtime",
       "ToInt32",
       netValue
     ))

--- a/R/molecules-building-block.R
+++ b/R/molecules-building-block.R
@@ -99,7 +99,7 @@ MoleculesBuildingBlock <- R6::R6Class(
 #' @keywords internal
 .quantityTypeNetObject <- function(moleculeType) {
   rSharp::callStatic(
-    "System.Enum",
+    "System.Enum, System.Runtime",
     "ToObject",
     rSharp::getType("OSPSuite.Core.Domain.QuantityType"),
     as.integer(moleculeType)

--- a/R/quantity.R
+++ b/R/quantity.R
@@ -1,6 +1,6 @@
-WITH_DIMENSION_EXTENSION <- "OSPSuite.Core.Domain.WithDimensionExtensions"
-WITH_DISPLAY_UNIT_EXTENSION <- "OSPSuite.Core.Domain.WithDisplayUnitExtensions"
-QUANTITY_EXTENSIONS <- "OSPSuite.Core.Domain.QuantityExtensions"
+WITH_DIMENSION_EXTENSION <- "OSPSuite.Core.Domain.WithDimensionExtensions, OSPSuite.Core"
+WITH_DISPLAY_UNIT_EXTENSION <- "OSPSuite.Core.Domain.WithDisplayUnitExtensions, OSPSuite.Core"
+QUANTITY_EXTENSIONS <- "OSPSuite.Core.Domain.QuantityExtensions, OSPSuite.Core"
 
 #' @title Quantity
 #' @docType class

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -1,4 +1,4 @@
-MODEL_CORE_SIMULATION_EXTENSIONS <- "OSPSuite.Core.Domain.ModelCoreSimulationExtensions"
+MODEL_CORE_SIMULATION_EXTENSIONS <- "OSPSuite.Core.Domain.ModelCoreSimulationExtensions, OSPSuite.Core"
 
 #' @title Simulation
 #' @docType class

--- a/R/utilities-individual.R
+++ b/R/utilities-individual.R
@@ -16,7 +16,7 @@
 createIndividual <- function(individualCharacteristics) {
   validateIsOfType(individualCharacteristics, "IndividualCharacteristics")
 
-  individualFactory <- rSharp::callStatic("PKSim.R.Api", "GetIndividualFactory")
+  individualFactory <- rSharp::callStatic("PKSim.R.Api, PKSim.R", "GetIndividualFactory")
   createIndividualResults <- individualFactory$call(
     "CreateIndividual",
     individualCharacteristics
@@ -58,7 +58,7 @@ createIndividual <- function(individualCharacteristics) {
 createDistributions <- function(individualCharacteristics) {
   validateIsOfType(individualCharacteristics, "IndividualCharacteristics")
 
-  individualFactory <- rSharp::callStatic("PKSim.R.Api", "GetIndividualFactory")
+  individualFactory <- rSharp::callStatic("PKSim.R.Api, PKSim.R", "GetIndividualFactory")
   distributedParameters <- individualFactory$call(
     "DistributionsFor",
     individualCharacteristics

--- a/R/utilities-pksim.R
+++ b/R/utilities-pksim.R
@@ -16,7 +16,7 @@ initPKSim <- function() {
   }
 
   rSharp::loadAssembly(pksimR)
-  rSharp::callStatic("PKSim.R.Api", "InitializeOnce")
+  rSharp::callStatic("PKSim.R.Api, PKSim.R", "InitializeOnce")
 
   # Only set the flag if initialization was successful
   ospsuiteEnv$isPKSimLoaded <- TRUE

--- a/R/utilities-population.R
+++ b/R/utilities-population.R
@@ -199,7 +199,7 @@ loadAgingDataFromCSV <- function(filePath) {
 createPopulation <- function(populationCharacteristics) {
   validateIsOfType(populationCharacteristics, "PopulationCharacteristics")
 
-  populationFactory <- rSharp::callStatic("PKSim.R.Api", "GetPopulationFactory")
+  populationFactory <- rSharp::callStatic("PKSim.R.Api, PKSim.R", "GetPopulationFactory")
   results <- populationFactory$call(
     "CreatePopulation",
     populationCharacteristics

--- a/R/utilities-snapshots.R
+++ b/R/utilities-snapshots.R
@@ -98,7 +98,7 @@ runSimulationsFromSnapshot <- function(
 
   tryCatch(
     {
-      invisible(rSharp::callStatic("PKSim.R.Api", "RunJson", JsonRunOptions))
+      invisible(rSharp::callStatic("PKSim.R.Api, PKSim.R", "RunJson", JsonRunOptions))
     },
     error = function(e) {
       message <- stringr::str_extract(as.character(e), "(?<=Message: )[^\\n]*")
@@ -161,7 +161,7 @@ convertSnapshot <- function(..., format, output = ".", runSimulations = FALSE) {
   tryCatch(
     {
       invisible(rSharp::callStatic(
-        "PKSim.R.Api",
+        "PKSim.R.Api, PKSim.R",
         "RunSnapshot",
         SnapshotRunOptions
       ))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -66,7 +66,7 @@
 .netEnumName <- function(enumType, enumValue) {
   netTypeObj <- rSharp::getType(enumType)
   rSharp::callStatic(
-    "System.Enum",
+    "System.Enum, System.Runtime",
     methodName = "GetName",
     netTypeObj,
     enumValue
@@ -103,7 +103,7 @@ clearMemory <- function(clearSimulationsCache = FALSE) {
   gc()
 
   # then forces `.NET` garbage collection
-  rSharp::callStatic("OSPSuite.R.Api", "ForceGC")
+  rSharp::callStatic("OSPSuite.R.Api, OSPSuite.R", "ForceGC")
   invisible()
 }
 


### PR DESCRIPTION
Fixes #1948

## Summary

Append the owning assembly to every type string passed to `rSharp::callStatic` so the .NET 10 type loader can skip cross-assembly probing.

```diff
-rSharp::callStatic("OSPSuite.R.Api", "ForceGC")
+rSharp::callStatic("OSPSuite.R.Api, OSPSuite.R", "ForceGC")
```

For type strings stored in constants (`WITH_DIMENSION_EXTENSION`, `QUANTITY_EXTENSIONS`, `FormulaExtensions`, `EntityExtensions`, `WITH_DISPLAY_UNIT_EXTENSION`, `MODEL_CORE_SIMULATION_EXTENSIONS`) the suffix is added once at the declaration and propagates to every call site, including the two indirect sites in `R/dot-net-wrapper.R`.

## Measured impact

Full `testthat` suite (1136 tests, 86 files, 2 parallel workers), same machine, same R / rSharp / .NET 10 install:

| Metric | Baseline | Assembly-qualified | Δ | % saved |
|---|---:|---:|---:|---:|
| **Wall time** | **244.303 s** | **187.989 s** | **-56.314 s** | **-23.0 %** |
| testthat duration | 242.2 s | 186.2 s | -56.0 s | -23.1 % |
| user.self (R) | 26.420 s | 22.790 s | -3.630 s | -13.7 % |
| sys.self (R) | 3.640 s | 2.390 s | -1.250 s | -34.3 % |

Same test outcome both runs: **2174 pass / 0 fail / 1 skip / 95 warn**.

## Changes

- **8 constant declarations** updated: `R/data-column.R:1-2`, `R/quantity.R:1-3`, `R/simulation.R:1`, `R/entity.R:1`, `R/formula.R:1`
- **14 literal call sites** updated across `R/get-net-task.R`, `R/init-package.R`, `R/molecules-building-block.R`, `R/utilities.R`, `R/utilities-individual.R`, `R/utilities-pksim.R`, `R/utilities-population.R`, `R/utilities-snapshots.R`

Type string → assembly mapping used:

| Type string | Assembly |
|-------------|----------|
| `OSPSuite.R.Api` | `OSPSuite.R` |
| `MoBi.R.Api` | `MoBi.R` |
| `PKSim.R.Api` | `PKSim.R` |
| `OSPSuite.Core.Domain.EntityExtensions` | `OSPSuite.Core` |
| `OSPSuite.Core.Domain.WithDimensionExtensions` | `OSPSuite.Core` |
| `OSPSuite.Core.Domain.WithDisplayUnitExtensions` | `OSPSuite.Core` |
| `OSPSuite.Core.Domain.QuantityExtensions` | `OSPSuite.Core` |
| `OSPSuite.Core.Domain.ModelCoreSimulationExtensions` | `OSPSuite.Core` |
| `OSPSuite.Core.Domain.Formulas.FormulaExtensions` | `OSPSuite.Core` |
| `System.Enum` | `System.Runtime` |
| `System.Convert` | `System.Runtime` |

## Test plan

- [x] CI test job is green on Windows (baseline run on dev box was 2174/0/1/95 — should match)
- [x] No behavior change in any existing test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated internal .NET type identifier references across multiple R modules to use fully-qualified assembly qualifiers for framework integration.
* Affected areas include data handling, entity management, formulas, task execution, package initialization, molecule building, quantity handling, simulations, and utility functions.
* No changes to public-facing APIs or end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/OSPSuite-R/pull/1949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->