### PR TITLE
Backport v13 vignette formatting to main

### DIFF
--- a/vignettes/create-individual.Rmd
+++ b/vignettes/create-individual.Rmd
@@ -33,17 +33,19 @@ library(ospsuite)
 
 # If no unit is specified, the default units are used. For "weight" it is "kg", for "age" it is "year(s)".
 individualCharacteristics <- createIndividualCharacteristics(
-  species    = Species$Human,
+  species = Species$Human,
   population = HumanPopulation$Japanese_Population,
-  gender     = Gender$Female,
-  weight     = 75,
-  height     = 1.75,
+  gender = Gender$Female,
+  weight = 75,
+  height = 1.75,
   heightUnit = "m",
-  age        = 43
+  age = 43
 )
 print(individualCharacteristics)
 
-individual <- createIndividual(individualCharacteristics = individualCharacteristics)
+individual <- createIndividual(
+  individualCharacteristics = individualCharacteristics
+)
 
 # we will not be printing this given the long length of the output, but you can
 # see the details by running:
@@ -58,8 +60,6 @@ The output contains two lists of parameters:
 When applying the generated individual parameter set to a simulation in R, only parameters from the `distributedParameters` should be overwritten, otherwise formula dependencies may be destroyed. Generated parameter values can be conveniently applied using the `setParameterValuesByPath` method:
 
 ```{r setIndividualParameters}
-library(ospsuite)
-
 # Load simulation
 simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
 print(simFilePath)
@@ -68,8 +68,8 @@ sim <- loadSimulation(simFilePath)
 # Apply individual parameters
 setParameterValuesByPath(
   parameterPaths = individual$distributedParameters$paths,
-  values         = individual$distributedParameters$values,
-  simulation     = sim
+  values = individual$distributedParameters$values,
+  simulation = sim
 )
 ```
 
@@ -78,27 +78,30 @@ setParameterValuesByPath(
 The PK-Sim database includes ontogeny information for some proteins (see (PK-Sim Ontogeny Database)[https://github.com/Open-Systems-Pharmacology/OSPSuite.Documentation/blob/master/PK-Sim%20Ontogeny%20Database%20Version%207.3.pdf]). For a protein molecule present in the simulation, it is possible to add the ontogeny information on one of the predefined proteins. For example, it is possible to set the ontogeny of the protein `MyProtein` to the value of the ontogeny of a CYP3A4 enzyme for the specified individual. The list of supported ontogenies is stored in the `StandardOntogeny`-list.
 
 ```{r addOntogeny}
-library(ospsuite)
-
 # All supported ontogenies
 print(StandardOntogeny)
 
 # Create the ontogeny for the protein "MyProtein" based on ontology of CYP3A4
-myProteinOntogeny <- MoleculeOntogeny$new(molecule = "MyProtein", ontogeny = StandardOntogeny$CYP3A4)
+myProteinOntogeny <- MoleculeOntogeny$new(
+  molecule = "MyProtein",
+  ontogeny = StandardOntogeny$CYP3A4
+)
 print(myProteinOntogeny)
 
 # Add this ontogeny to the individual characteristics used to create the individual parameters set
 individualCharacterstics <- createIndividualCharacteristics(
-  species            = Species$Human,
-  population         = HumanPopulation$Japanese_Population,
-  gender             = Gender$Female,
-  weight             = 75,
-  height             = 1.75,
-  heightUnit         = "m",
-  age                = 43,
+  species = Species$Human,
+  population = HumanPopulation$Japanese_Population,
+  gender = Gender$Female,
+  weight = 75,
+  height = 1.75,
+  heightUnit = "m",
+  age = 43,
   moleculeOntogenies = myProteinOntogeny
 )
 print(individualCharacterstics)
 
-individual <- createIndividual(individualCharacteristics = individualCharacterstics)
+individual <- createIndividual(
+  individualCharacteristics = individualCharacterstics
+)
 ```

--- a/vignettes/create-run-population.Rmd
+++ b/vignettes/create-run-population.Rmd
@@ -37,27 +37,27 @@ print(myPopulation)
 Similar to creating individual parameter sets (see [Creating individuals](create-individual.html)), a population is created from *population characteristics* created by calling the method `createPopulationCharacteristics()`. To see the list of available values for the arguments `species` and `population` (only for human), use the enums `Species` and `HumanPopulation`, respectively. The returned object of type `PopulationCharacteristics` is then passed to the function `createPopulation` to generate a set of parameter values. The algorithm behind is the same used in PK-Sim when creating an population. Molecule ontogenies can be added as described in the vignette [Creating individuals](create-individual.html).
 
 ```{r createPop}
-library(ospsuite)
-
 # If no unit is specified, the default units are used. For "height" it is "dm", for "weight" it is "kg", for "age" it is "year(s)".
 populationCharacteristics <- createPopulationCharacteristics(
-  species             = Species$Human,
-  population          = HumanPopulation$Asian_Tanaka_1996,
+  species = Species$Human,
+  population = HumanPopulation$Asian_Tanaka_1996,
   numberOfIndividuals = 50,
   proportionOfFemales = 50,
-  weightMin           = 30,
-  weightMax           = 98,
-  weightUnit          = "kg",
-  heightMin           = NULL,
-  heightMax           = NULL,
-  ageMin              = 0,
-  ageMax              = 80,
-  ageUnit             = "year(s)"
+  weightMin = 30,
+  weightMax = 98,
+  weightUnit = "kg",
+  heightMin = NULL,
+  heightMax = NULL,
+  ageMin = 0,
+  ageMax = 80,
+  ageUnit = "year(s)"
 )
 print(populationCharacteristics)
 
 # Create population from population characteristics
-result <- createPopulation(populationCharacteristics = populationCharacteristics)
+result <- createPopulation(
+  populationCharacteristics = populationCharacteristics
+)
 myPopulation <- result$population
 print(myPopulation)
 ```
@@ -67,14 +67,15 @@ print(myPopulation)
 To run a population simulation, the `Population` object created by the `createPopulation` method must be passed to the `runSimulation()` method:
 
 ```{r runPop}
-library(ospsuite)
-
 # Load simulation
 simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
 sim <- loadSimulation(simFilePath)
 
 # Run population simulation
-simulationResults <- runSimulations(simulations = sim, population = myPopulation)[[1]]
+simulationResults <- runSimulations(
+  simulations = sim,
+  population = myPopulation
+)[[1]]
 print(simulationResults)
 ```
 
@@ -96,7 +97,11 @@ simRunOptions$numberOfCores <- 3
 simRunOptions$showProgress <- TRUE
 
 # Run population simulation with custom options
-populationResults <- runSimulations(simulations = sim, population = myPopulation, simulationRunOptions = simRunOptions)[[1]]
+populationResults <- runSimulations(
+  simulations = sim,
+  population = myPopulation,
+  simulationRunOptions = simRunOptions
+)[[1]]
 print(populationResults)
 ```
 
@@ -123,7 +128,10 @@ The values of `IndividualId`, `Time`, and the simulated outputs, are appended fo
 resultsPath <- populationResults$allQuantityPaths[[1]]
 print(resultsPath)
 
-resultsData <- getOutputValues(populationResults, quantitiesOrPaths = resultsPath)
+resultsData <- getOutputValues(
+  populationResults,
+  quantitiesOrPaths = resultsPath
+)
 
 resultsTime <- resultsData$data$Time
 resultsValues <- resultsData$data$`Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)`
@@ -139,7 +147,11 @@ resultsPath <- populationResults$allQuantityPaths[[1]]
 print(resultsPath)
 
 # Get only the results for individuals with IDs 1 and 2
-resultsData <- getOutputValues(populationResults, quantitiesOrPaths = resultsPath, individualIds = c(1, 2))
+resultsData <- getOutputValues(
+  populationResults,
+  quantitiesOrPaths = resultsPath,
+  individualIds = c(1, 2)
+)
 
 resultsTime <- resultsData$data$Time
 resultsValues <- resultsData$data$`Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)`

--- a/vignettes/efficient-calculations.Rmd
+++ b/vignettes/efficient-calculations.Rmd
@@ -56,7 +56,10 @@ library(ospsuite)
 # Load and run the simulation
 simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
 sim <- loadSimulation(simFilePath)
-doseParameter <- getAllParametersMatching(toPathString("Applications", "**", "Dose"), sim)[[1]]
+doseParameter <- getAllParametersMatching(
+  toPathString("Applications", "**", "Dose"),
+  sim
+)[[1]]
 
 # run for dose 100mg
 doseParameter$value <- toBaseUnit(doseParameter, 100, "mg")
@@ -84,13 +87,15 @@ When the simulation run time (5) is much greater than the loading (1) and initia
 Consider the following implementation:
 
 ```{r ParallelRun, eval=TRUE}
-library(ospsuite)
 # Load and run the simulation
 simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
 
 loadSimulationWithDose <- function(doseInMg) {
   sim <- loadSimulation(simFilePath, loadFromCache = FALSE)
-  doseParameter <- getAllParametersMatching(toPathString("Applications", "**", "Dose"), sim)[[1]]
+  doseParameter <- getAllParametersMatching(
+    toPathString("Applications", "**", "Dose"),
+    sim
+  )[[1]]
   doseParameter$value <- toBaseUnit(doseParameter, doseInMg, "mg")
   return(sim)
 }
@@ -104,7 +109,9 @@ sim500 <- loadSimulationWithDose(doseInMg = 500)
 
 
 # Runs the simulation in parallel
-results <- runSimulations(simulations = list(sim100, sim200, sim300, sim400, sim500))
+results <- runSimulations(
+  simulations = list(sim100, sim200, sim300, sim400, sim500)
+)
 
 # Results in now a list of SimulationResults
 ```
@@ -125,7 +132,6 @@ the `Simulation` object, we do not have access to any parameter/species values n
 the outputs or simulation time.
 
 ```{r BatchRunInit, eval=TRUE}
-library(ospsuite)
 simFilePath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
 
 # We load the simulation for which the batches will be created
@@ -136,7 +142,10 @@ sim1 <- loadSimulation(simFilePath, loadFromCache = FALSE)
 parameterPaths <- c("Aciclovir|Lipophilicity", "Aciclovir|Permeability")
 
 # define a first simulation batch
-simBatch1 <- createSimulationBatch(simulation = sim1, parametersOrPaths = parameterPaths)
+simBatch1 <- createSimulationBatch(
+  simulation = sim1,
+  parametersOrPaths = parameterPaths
+)
 
 # for the second batch, we will vary Molecular Weight
 simBatch2 <- createSimulationBatch(
@@ -211,11 +220,17 @@ State variable parameters, i.e., those defined by a right hand side (RHS), are t
 will result in an error:
 
 ```{r BatchRunStateVarParam, error = TRUE, purl = FALSE}
-stateVariableParam <- getParameter(path = "Organism|Lumen|Stomach|Liquid", container = sim1)
+stateVariableParam <- getParameter(
+  path = "Organism|Lumen|Stomach|Liquid",
+  container = sim1
+)
 print(stateVariableParam)
 
 # Create simulation batch with state variable parameter set as a variable parameter
-simBatch <- createSimulationBatch(simulation = sim1, parametersOrPaths = stateVariableParam)
+simBatch <- createSimulationBatch(
+  simulation = sim1,
+  parametersOrPaths = stateVariableParam
+)
 
 # Add run values
 resId <- simBatch$addRunValues(parameterValues = 0.5)
@@ -226,9 +241,15 @@ results <- runSimulationBatches(simBatch)
 Instead, the state variable parameter should be treated as a species and set as a variable molecule start value.
 
 ```{r BatchRunStateVarMolecule, eval=TRUE}
-stateVariableParam <- getParameter(path = "Organism|Lumen|Stomach|Liquid", container = sim1)
+stateVariableParam <- getParameter(
+  path = "Organism|Lumen|Stomach|Liquid",
+  container = sim1
+)
 # Create simulation batch with state variable parameter set as a variable molecule
-simBatch <- createSimulationBatch(simulation = sim1, moleculesOrPaths = stateVariableParam)
+simBatch <- createSimulationBatch(
+  simulation = sim1,
+  moleculesOrPaths = stateVariableParam
+)
 # Add run values
 resId <- simBatch$addRunValues(initialValues = 0.5)
 # Try to run batch

--- a/vignettes/sensitivity-analysis.Rmd
+++ b/vignettes/sensitivity-analysis.Rmd
@@ -52,7 +52,10 @@ sa <- SensitivityAnalysis$new(simulation = sim)
 print(sa)
 
 # Create a `SensitivityAnalysis` with specified parameters
-sa <- SensitivityAnalysis$new(simulation = sim, parameterPaths = c("Organism|Q", "Organism|Volume"))
+sa <- SensitivityAnalysis$new(
+  simulation = sim,
+  parameterPaths = c("Organism|Q", "Organism|Volume")
+)
 print(sa)
 
 # Show which parameters will be varied
@@ -66,17 +69,18 @@ New parameters can be added to an existing `SensitivityAnalysis` by calling the 
 - In such cases, calling `addParameterPaths()` will only vary the newly added parameters.
 
 ```{r addPathsToSensitivityAnalysis}
-library(ospsuite)
-
 # Load simulation
 simFilePath <- system.file("extdata", "simple.pkml", package = "ospsuite")
 sim <- loadSimulation(simFilePath)
 
 # Create a `SensitivityAnalysis` with specified parameters
-sa <- SensitivityAnalysis$new(simulation = sim, parameterPaths = c(
-  "Organism|Q",
-  "Organism|Volume"
-))
+sa <- SensitivityAnalysis$new(
+  simulation = sim,
+  parameterPaths = c(
+    "Organism|Q",
+    "Organism|Volume"
+  )
+)
 # Add new parameter
 sa$addParameterPaths("R1|k1")
 
@@ -139,7 +143,11 @@ print(saResult)
 
 # Get sensitivities for the parameter "AUC_inf" of the simulated output with a threshold of 0.8
 outputPath <- sim$outputSelections$allOutputs[[1]]$path
-sensitivities <- saResult$allPKParameterSensitivitiesFor(pkParameterName = "AUC_inf", outputPath = outputPath, totalSensitivityThreshold = 0.8)
+sensitivities <- saResult$allPKParameterSensitivitiesFor(
+  pkParameterName = "AUC_inf",
+  outputPath = outputPath,
+  totalSensitivityThreshold = 0.8
+)
 print(sensitivities)
 ```
 
@@ -162,8 +170,14 @@ saResult <- runSensitivityAnalysis(sa)
 
 # Export to csv
 saResultPath <- system.file("extdata", "SAResult.csv", package = "ospsuite")
-exportSensitivityAnalysisResultsToCSV(results = saResult, filePath = saResultPath)
+exportSensitivityAnalysisResultsToCSV(
+  results = saResult,
+  filePath = saResultPath
+)
 
 # Load from csv
-saResultLoaded <- importSensitivityAnalysisResultsFromCSV(filePaths = saResultPath, simulation = sim)
+saResultLoaded <- importSensitivityAnalysisResultsFromCSV(
+  filePaths = saResultPath,
+  simulation = sim
+)
 ```


### PR DESCRIPTION
Backports the v13 vignette formatting changes to `main` (continuation of the v12-safe backport series).

All four diffs are **documentation-only**:
- air-formatter reflow of code chunks (wrap long calls onto multiple lines, drop aligned-`=` spacing)
- removal of redundant in-chunk `library(ospsuite)` calls (already loaded earlier in each vignette)

No semantic, API, or output changes — nothing v13-specific (no .NET 10, MoBi, or behavioral changes).

Files:
- `vignettes/create-individual.Rmd`
- `vignettes/create-run-population.Rmd`
- `vignettes/efficient-calculations.Rmd`
- `vignettes/sensitivity-analysis.Rmd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved code example formatting across vignettes for enhanced readability.
  * Reformatted code examples to use consistent multi-line function-call style.
  * Simplified example code by removing redundant library declarations while preserving functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->