### PR TITLE
Adopt focused reusable release workflows

### DIFF
--- a/.github/workflows/check-dev-deps.yaml
+++ b/.github/workflows/check-dev-deps.yaml
@@ -1,0 +1,17 @@
+name: Check against development dependencies
+
+# Nightly R-CMD-check against the current (development) OSP dependencies, i.e.
+# the unpinned Remotes as they stand in DESCRIPTION. Complements
+# check-released-deps.yaml, which pins Remotes to @*release and checks against
+# the released dependencies instead.
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # Run at 4 AM UTC daily (after released-deps at 3 AM)
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  check-dev-deps:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main

--- a/.github/workflows/check-released-deps.yaml
+++ b/.github/workflows/check-released-deps.yaml
@@ -1,5 +1,9 @@
 name: Check against released dependencies
 
+# Nightly R-CMD-check against the latest *released* OSP dependencies: the
+# reusable workflow pins Remotes to @*release before checking. Complements
+# check-dev-deps.yaml, which checks against the current (development) deps.
+
 on:
   schedule:
     - cron: '0 3 * * *' # Run at 3 AM UTC daily (after renv nightly at 2 AM)

--- a/.github/workflows/dev-pr.yaml
+++ b/.github/workflows/dev-pr.yaml
@@ -1,0 +1,21 @@
+name: Dev PR
+
+# Manually open a "restore development mode" pull request: runs
+# usethis::use_dev_version() (Version x.y.z -> x.y.z.9000 and a new NEWS.md
+# development heading), unpins Remotes (strips @*release), then opens a
+# `dev-pr-<version>` PR. Run after a release, or on demand.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dev-pr:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/dev-pr.yaml@main
+    with:
+      app-id: ${{ vars.VERSION_BUMPER_APPID }}
+    secrets:
+      private-key: ${{ secrets.VERSION_BUMPER_SECRET }}

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -1,17 +1,22 @@
-name: Main-Workflow
+name: Merge to Main Workflow
+
+# Runs on push to main (i.e. when a PR merges). bump-dev-version advances a dev
+# version's trailing component (release versions no-op); the checks run in
+# parallel. Tagging and publishing a release are not automatic here: that is a
+# deliberate manual dispatch (see release-pr.yaml then publish.yaml).
 
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 permissions: write-all
 
 jobs:
-  bump-dev-version: # only do that when actually merging in main/develop branch
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump_dev_version_tag_branch.yaml@main
+  # Pushes the dev bump directly to the protected main branch, so it needs an
+  # App token whose identity is in the branch ruleset's bypass list.
+  bump-dev-version:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump-dev-version.yaml@main
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:
@@ -19,17 +24,14 @@ jobs:
 
   R-CMD-Check:
     if: ${{ !cancelled() }}
-    needs: [bump-dev-version]
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
 
   test-coverage:
     if: ${{ !cancelled() }}
-    needs: [bump-dev-version]
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pkgdown:
     if: ${{ !cancelled() }}
-    needs: [bump-dev-version]
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -36,4 +36,6 @@ jobs:
 
   pkgdown:
     if: ${{ !cancelled() }}
+    permissions:
+      contents: write # deploys the built pkgdown site
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -8,7 +8,6 @@ name: Merge to Main Workflow
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -37,4 +37,5 @@ jobs:
     if: ${{ !cancelled() }}
     permissions:
       contents: write # deploys the built pkgdown site
+      pull-requests: read # the workflow's check-changes job reads PR file changes
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -10,12 +10,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: write-all
+permissions: read-all
 
 jobs:
   # Pushes the dev bump directly to the protected main branch, so it needs an
   # App token whose identity is in the branch ruleset's bypass list.
   bump-dev-version:
+    permissions:
+      contents: write # pushes the dev-version bump to main
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump-dev-version.yaml@main
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,9 @@ name: Publish Release Workflow
 # DESCRIPTION is at x.y.z). R-CMD-check builds the per-OS binaries; publish-release
 # then force-tags vX.Y.Z at the main HEAD and creates/updates the GitHub Release
 # with NEWS.md notes and the binaries attached. A dev version is a no-op.
+#
+# workflow_dispatch lets the operator pick any branch in the Actions UI, so both
+# jobs guard on github.ref to ensure the release is only ever cut from main.
 
 on:
   workflow_dispatch:
@@ -12,11 +15,12 @@ permissions: read-all
 
 jobs:
   R-CMD-Check:
+    if: ${{ github.ref == 'refs/heads/main' }}
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
 
   publish-release:
     needs: [R-CMD-Check]
-    if: ${{ needs.R-CMD-Check.result == 'success' }}
+    if: ${{ github.ref == 'refs/heads/main' && needs.R-CMD-Check.result == 'success' }}
     permissions:
       contents: write # force-tags vX.Y.Z and creates/updates the GitHub Release
       actions: read # download-artifact reads the run's binaries

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,9 @@ name: Publish Release Workflow
 # then force-tags vX.Y.Z at the main HEAD and creates/updates the GitHub Release
 # with NEWS.md notes and the binaries attached. A dev version is a no-op.
 #
-# workflow_dispatch lets the operator pick any branch in the Actions UI, so both
-# jobs guard on github.ref to ensure the release is only ever cut from main.
+# workflow_dispatch lets the operator pick any branch in the Actions UI, so the
+# guard-branch job fails the whole run with an explicit message when dispatched
+# from anything other than main; the build/publish jobs depend on it.
 
 on:
   workflow_dispatch:
@@ -14,13 +15,21 @@ on:
 permissions: read-all
 
 jobs:
+  guard-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure the workflow runs from main
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "::error::This workflow must be run from the 'main' branch, but it was dispatched from '${{ github.ref_name }}'. Re-run it with 'main' selected as the branch."
+          exit 1
+
   R-CMD-Check:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: [guard-branch]
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
 
   publish-release:
-    needs: [R-CMD-Check]
-    if: ${{ github.ref == 'refs/heads/main' && needs.R-CMD-Check.result == 'success' }}
+    needs: [guard-branch, R-CMD-Check]
     permissions:
       contents: write # force-tags vX.Y.Z and creates/updates the GitHub Release
       actions: read # download-artifact reads the run's binaries

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ name: Publish Release Workflow
 on:
   workflow_dispatch:
 
-permissions: write-all
+permissions: read-all
 
 jobs:
   R-CMD-Check:
@@ -17,4 +17,7 @@ jobs:
   publish-release:
     needs: [R-CMD-Check]
     if: ${{ needs.R-CMD-Check.result == 'success' }}
+    permissions:
+      contents: write # force-tags vX.Y.Z and creates/updates the GitHub Release
+      actions: read # download-artifact reads the run's binaries
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/publish-release.yaml@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,20 @@
+name: Publish Release Workflow
+
+# Manual "publish the release": dispatch after a release PR has merged (so
+# DESCRIPTION is at x.y.z). R-CMD-check builds the per-OS binaries; publish-release
+# then force-tags vX.Y.Z at the main HEAD and creates/updates the GitHub Release
+# with NEWS.md notes and the binaries attached. A dev version is a no-op.
+
+on:
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  R-CMD-Check:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+
+  publish-release:
+    needs: [R-CMD-Check]
+    if: ${{ needs.R-CMD-Check.result == 'success' }}
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/publish-release.yaml@main

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,10 +7,12 @@ name: Pull Request Workflow
 on:
   pull_request:
 
-permissions: write-all
+permissions: read-all
 
 jobs:
   sync-remotes:
+    permissions:
+      contents: write # commits the synced Remotes back to the PR branch
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/sync-remotes.yaml@main
     secrets: inherit
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -31,4 +31,6 @@ jobs:
   pkgdown:
     needs: [sync-remotes]
     if: ${{ !cancelled() }}
+    permissions:
+      contents: write # required by the pkgdown reusable workflow (no deploy on PRs)
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -33,4 +33,5 @@ jobs:
     if: ${{ !cancelled() }}
     permissions:
       contents: write # required by the pkgdown reusable workflow (no deploy on PRs)
+      pull-requests: read # the workflow's check-changes job reads PR file changes
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,32 @@
+name: Pull Request Workflow
+
+# Runs on every pull request. sync-remotes pins/unpins `Remotes:` in DESCRIPTION
+# to match the package Version and commits the fix to the PR branch; the checks
+# then run on that synced tree so what gets validated is what will be merged.
+
+on:
+  pull_request:
+
+permissions: write-all
+
+jobs:
+  sync-remotes:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/sync-remotes.yaml@main
+    secrets: inherit
+
+  R-CMD-Check:
+    needs: [sync-remotes]
+    if: ${{ !cancelled() }} # a skipped fork-PR sync must not block the check
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+
+  test-coverage:
+    needs: [sync-remotes]
+    if: ${{ !cancelled() }}
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  pkgdown:
+    needs: [sync-remotes]
+    if: ${{ !cancelled() }}
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,0 +1,33 @@
+name: Release PR
+
+# Manually open a release pull request: runs usethis::use_version(<which>) to
+# set the release Version and rename the NEWS.md development heading, pins
+# Remotes to @*release, then opens a `release-pr-<version>` PR. The PR is
+# validated by the normal pull request pipeline before merge; tagging and the
+# GitHub Release happen afterwards via a manual dispatch of publish.yaml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      which:
+        description: 'Which component to bump for the release.'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-pr:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/release-pr.yaml@main
+    with:
+      which: ${{ inputs.which }}
+      app-id: ${{ vars.VERSION_BUMPER_APPID }}
+    secrets:
+      private-key: ${{ secrets.VERSION_BUMPER_SECRET }}

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 
-[![Build Badge](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite-R/main-workflow.yaml?branch=main&label=Build)](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/workflows/main-workflow.yaml)
+[![Build Badge](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite-R/merge-to-main.yaml?branch=main&label=Build)](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/workflows/merge-to-main.yaml)
 [![Codecov test coverage Badge](https://codecov.io/gh/Open-Systems-Pharmacology/OSPSuite-R/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Open-Systems-Pharmacology/OSPSuite-R?branch=main)
 
 <!-- badges: end -->
@@ -247,7 +247,7 @@ The package follows the versioning process described in the [OSP R collaboration
 guide](https://dev.open-systems-pharmacology.org/r-development-resources/collaboration_guide#releasing-versions).
 
 For development versions, [this GitHub
-action](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/blob/main/.github/workflows/main-workflow.yaml#L11-L17)
+action](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/blob/main/.github/workflows/merge-to-main.yaml)
 automatically increments the `.9000` version suffix when pull requests are merged.
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <!-- badges: start -->
 
 [![Build
-Badge](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite-R/main-workflow.yaml?branch=main&label=Build)](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/workflows/main-workflow.yaml)
+Badge](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/OSPSuite-R/merge-to-main.yaml?branch=main&label=Build)](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/workflows/merge-to-main.yaml)
 [![Codecov test coverage
 Badge](https://codecov.io/gh/Open-Systems-Pharmacology/OSPSuite-R/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Open-Systems-Pharmacology/OSPSuite-R?branch=main)
 
@@ -125,6 +125,7 @@ dependencies first.
 
 ``` r
 # Install dependencies (e.g. R6) which are on CRAN
+install.packages("checkmate")
 install.packages("cli")
 install.packages("crayon")
 install.packages("data.table")
@@ -136,12 +137,12 @@ install.packages("jsonlite")
 install.packages("lifecycle")
 install.packages("logger")
 install.packages("openxlsx")
+install.packages("ospsuite.plots")
 install.packages("patchwork")
 install.packages("purrr")
 install.packages("R6")
 install.packages("readr")
 install.packages("rlang")
-install.packages("showtext")
 install.packages("stringi")
 install.packages("stringr")
 install.packages("tidyr")
@@ -150,8 +151,8 @@ install.packages("xml2")
 
 #### Install non-CRAN dependencies
 
-Pre-built packages are available as binary files (*.zip for Windows,
-*.tar.gz for Linux) Download the OSPSuite-R binary archive from the
+Pre-built packages are available as binary files (*.zip for Windows,*
+.tar.gz for Linux) Download the OSPSuite-R binary archive from the
 [releases
 page](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/releases).
 Download and install these additional non-CRAN dependencies:
@@ -255,7 +256,7 @@ collaboration
 guide](https://dev.open-systems-pharmacology.org/r-development-resources/collaboration_guide#releasing-versions).
 
 For development versions, [this GitHub
-action](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/blob/main/.github/workflows/main-workflow.yaml#L11-L17)
+action](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/blob/main/.github/workflows/merge-to-main.yaml)
 automatically increments the `.9000` version suffix when pull requests
 are merged.
 


### PR DESCRIPTION
Adopts the focused reusable workflows from [Open-Systems-Pharmacology/Workflows#232](https://github.com/Open-Systems-Pharmacology/Workflows/pull/232), retiring the deprecated `bump_dev_version_tag_branch.yaml`. The all-in-one post-merge job is split across event-specific callers so `Remotes` pinning is validated in the PR before merge, and publishing a release (tag + GitHub Release) becomes a deliberate manual dispatch rather than an automatic side effect of merging.

## How the workflows articulate

```mermaid
flowchart TD
    subgraph dispatch["Manual dispatch"]
      RPR["release-pr.yaml<br/>use_version(which) + pin Remotes"] -->|opens PR| RELPR(["Release PR"])
      DPR["dev-pr.yaml<br/>use_dev_version() + unpin Remotes"] -->|opens PR| DEVPR(["Back-to-dev PR"])
    end

    subgraph pr["pull-request.yaml (on: pull_request)"]
      SYNC["sync-remotes<br/>pin or unpin to match Version"] --> CHECK["R-CMD-Check / test-coverage / pkgdown<br/>(run on the synced tree)"]
    end

    RELPR --> pr
    DEVPR --> pr
    CONTRIB(["Dev contribution PR"]) --> pr

    pr -->|merge to main| MERGE

    subgraph MERGE["merge-to-main.yaml (on: push to main)"]
      direction TB
      MCHECK["R-CMD-Check / test-coverage / pkgdown"]
      BUMP["bump-dev-version<br/>bump .NNNN on a dev version"]
    end

    subgraph publish["publish.yaml (manual dispatch, after a release PR merges)"]
      PCHECK["R-CMD-Check<br/>(builds per-OS binaries)"] --> PUB["publish-release<br/>tag vX.Y.Z at main + GitHub Release + binaries"]
    end

    MERGE -.->|maintainer decides to release| publish

    subgraph nightly["Scheduled (cron)"]
      NDEV["check-dev-deps.yaml<br/>04:00 UTC, against development deps"]
      NREL["check-released-deps.yaml<br/>03:00 UTC, pin @*release, against released deps"]
    end
```

## Changes

- **`pull-request.yaml`** (replaces `main-workflow.yaml` on PRs): `sync-remotes` pins/unpins `Remotes` on the PR branch, then the checks run on the synced tree.
- **`merge-to-main.yaml`** (replaces `main-workflow.yaml` on push to `main`): `bump-dev-version` advances a dev version alongside the checks. Merging no longer tags.
- **`release-pr.yaml` / `dev-pr.yaml` / `publish.yaml`**: dispatch-only workflows for preparing a release, restoring development mode, and tagging + publishing the GitHub Release. `release-pr` / `dev-pr` open their PRs with the existing `VERSION_BUMPER_APPID` / `VERSION_BUMPER_SECRET` so the PR triggers CI.
- **`check-released-deps.yaml`** (renamed from `R-CMD-check-released-deps.yaml`) and new **`check-dev-deps.yaml`**: nightly checks paired by dependency kind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added scheduled and manually triggerable CI workflows to check both development and released dependency sets.
  * Introduced new manual workflows for creating version-bump and release PRs (patch/minor/major), plus a manual dev PR workflow.
  * Updated pull request automation to run consistency checks, coverage reporting, and documentation generation, with remote syncing.
  * Refined merge-to-main and publish workflows with updated triggers, permissions, and simplified job orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->