### PR TITLE
Capture Windows crash dumps in CI via temporary local check workflows

### DIFF
--- a/.github/workflows/R-CMD-check-build-crashdumps.yaml
+++ b/.github/workflows/R-CMD-check-build-crashdumps.yaml
@@ -1,0 +1,161 @@
+# TEMPORARY diagnostic copy — remove when #1996 is resolved.
+#
+# This is a local copy of
+# Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+# with two Windows-only steps added around "Check R package" ("Enable Windows crash
+# dump capture" / "Upload crash dumps"). It exists so we can collect a crash dump for
+# the intermittent 0xC0000005 access violation in Windows test runs (#1996) without
+# modifying the shared workflow used across the whole organisation.
+# Only pull-request.yaml points here; everything else still uses the shared workflow.
+
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+
+on:
+  workflow_call:
+    inputs:
+      ignore-renv:
+        description: 'Skip renv setup if set to true'
+        required: false
+        type: boolean
+        default: false
+      os-matrix:
+        description: 'JSON array of {os, r} objects for the build matrix. Defaults to all three platforms with R release.'
+        required: false
+        type: string
+        default: >-
+          [{"os": "${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}", "r": "release"},
+          {"os": "${{ vars.GHA_DEFAULT_RUNNER_UBUNTU || 'ubuntu-latest' }}", "r": "release"},
+          {"os": "${{ vars.GHA_DEFAULT_RUNNER_MACOS || 'macos-latest' }}", "r": "release"}]
+      build-binary:
+        description: 'Whether to build and upload the binary package. Set to false on PRs to save ~4 min per OS.'
+        required: false
+        type: boolean
+        default: true
+      setup-quarto:
+        description: 'Whether to install Quarto (needed for packages with Quarto vignettes).'
+        required: false
+        type: boolean
+        default: false
+      setup-pandoc:
+        description: 'Whether to install pandoc.'
+        required: false
+        type: boolean
+        default: true
+      setup-tinytex:
+        description: 'Whether to install TinyTeX (provides pdflatex for PDF manual builds).'
+        required: false
+        type: boolean
+        default: false
+      extra-packages:
+        description: 'Additional CI tool packages to install, on top of rcmdcheck (and pkgbuild when build-binary is true). One package per line.'
+        required: false
+        type: string
+        default: ''
+      dotnet-version:
+        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
+        required: false
+        type: string
+        default: '8.0.x'
+name: R-CMD-check-build.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON(inputs.os-matrix) }}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup R environment
+        id: setup-r-env
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        with:
+          r-version: ${{ matrix.config.r }}
+          setup-pandoc: ${{ inputs.setup-pandoc }}
+          setup-tinytex: ${{ inputs.setup-tinytex }}
+          setup-quarto: ${{ inputs.setup-quarto }}
+          ignore-renv: ${{ inputs.ignore-renv }}
+          dotnet-version: ${{ inputs.dotnet-version }}
+          extra-packages: |
+            rcmdcheck
+            ${{ inputs.build-binary && 'pkgbuild' || '' }}
+            ${{ inputs.extra-packages }}
+
+      # OSP R packages intermittently crash with an access violation (0xC0000005) on
+      # Windows runners (Open-Systems-Pharmacology/OSPSuite-R#1996). Register a
+      # machine-wide Windows Error Reporting LocalDumps key so any process that
+      # crashes during the check writes a full dump, uploaded below on failure.
+      - name: Enable Windows crash dump capture
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'crashdumps'
+          New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+          $wer = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
+          New-Item -Path "$wer\LocalDumps" -Force | Out-Null
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpFolder -Value $dumpDir -Type ExpandString
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
+          Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          args: 'c("--no-manual")'
+          build_args: 'c("--no-manual")'
+          error-on: 'c("error")'
+
+      - name: Upload crash dumps
+        if: failure() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-dumps-${{ matrix.config.os }}-r_${{ matrix.config.r }}
+          path: ${{ env.CRASH_DUMP_DIR }}/*.dmp
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Build binary package
+        if: inputs.build-binary
+        shell: Rscript {0}
+        run: |
+          output_dir <- file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "built_package")
+          dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+          tarball <- list.files("check", pattern = "\\.tar\\.gz$", full.names = TRUE)[1]
+          built <- pkgbuild::build(
+            path = tarball,
+            dest_path = output_dir,
+            binary = TRUE,
+            args = c("--preclean", "--install-tests")
+          )
+          cat("Built binary:", built, "\n")
+
+      - name: Get package name, version and R versions and store in environment
+        if: inputs.build-binary
+        run: |
+          echo "PKG_NAME=$(grep '^Package:' DESCRIPTION | sed 's/^Package:[[:space:]]*//')" >> $GITHUB_ENV
+          echo "PKG_VERSION=$(grep '^Version:' DESCRIPTION | sed 's/^Version:[[:space:]]*//')" >> $GITHUB_ENV
+          echo "R_VERSION=${{ steps.setup-r-env.outputs.installed-r-version }}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Upload built package
+        if: inputs.build-binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PKG_NAME }}-v${{ env.PKG_VERSION }}-${{ matrix.config.os }}-r_${{ env.R_VERSION }}
+          path: ${{ runner.temp }}/built_package/*

--- a/.github/workflows/R-CMD-check-build-crashdumps.yaml
+++ b/.github/workflows/R-CMD-check-build-crashdumps.yaml
@@ -111,7 +111,20 @@ jobs:
           Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
           Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
           Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          # GitHub runner images ship with WER reporting disabled, which also disables
+          # LocalDumps collection (observed: a 0xC0000005 crash left no dump). Re-enable it.
+          Set-ItemProperty -Path $wer -Name Disabled -Value 0 -Type DWord
+          $werPolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'
+          if (Test-Path $werPolicy) { Set-ItemProperty -Path $werPolicy -Name Disabled -Value 0 -Type DWord }
+          try { Set-Service WerSvc -StartupType Manual } catch {}
           "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # Belt and braces: the crashing R worker hosts CoreCLR (rSharp), whose
+          # unhandled-exception filter can terminate the process before WER runs.
+          # With these set, the runtime writes its own full dump on any fatal exception,
+          # independent of WER. %p expands to the crashing PID.
+          "DOTNET_DbgEnableMiniDump=1" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DOTNET_DbgMiniDumpType=4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DOTNET_DbgMiniDumpName=$dumpDir\coreclr.%p.dmp" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/crash-hunt-1996.yaml
+++ b/.github/workflows/crash-hunt-1996.yaml
@@ -6,8 +6,11 @@
 # identical Windows-only R CMD check jobs, each with Windows Error Reporting crash-dump
 # capture. Any job that crashes uploads a crash-hunt-dumps-<n> artifact.
 #
-# Dispatch from this branch, e.g.:
-#   gh workflow run crash-hunt-1996.yaml --ref ci/windows-crash-dumps-1996 -f runs=20
+# workflow_dispatch only works once a workflow exists on the default branch, so this
+# also triggers on every push to its own branch: start a hunt with an empty commit,
+#   git commit --allow-empty -m "trigger crash hunt" && git push
+# (push runs use the default of 20). If this ever lands on main, it also becomes
+# dispatchable: gh workflow run crash-hunt-1996.yaml -f runs=20
 #
 # At ~5% crash probability per run: 10 runs ≈ 40%, 20 runs ≈ 64%, 40 runs ≈ 87%
 # chance of catching at least one dump. max-parallel is capped so the hunt does not
@@ -16,6 +19,8 @@
 name: Crash hunt (#1996)
 
 on:
+  push:
+    branches: [ci/windows-crash-dumps-1996]
   workflow_dispatch:
     inputs:
       runs:
@@ -33,7 +38,8 @@ jobs:
       runs: ${{ steps.gen.outputs.runs }}
     steps:
       - id: gen
-        run: echo "runs=$(jq -cn "[range(1; ${{ inputs.runs }} + 1)]")" >> "$GITHUB_OUTPUT"
+        # inputs.runs is empty on push events; default to 20 there
+        run: echo "runs=$(jq -cn "[range(1; ${{ inputs.runs || 20 }} + 1)]")" >> "$GITHUB_OUTPUT"
 
   hunt:
     needs: generate-matrix

--- a/.github/workflows/crash-hunt-1996.yaml
+++ b/.github/workflows/crash-hunt-1996.yaml
@@ -1,0 +1,88 @@
+# TEMPORARY diagnostic workflow — remove together with the *-crashdumps.yaml copies (#1998).
+#
+# The intermittent Windows access violation (#1996, upstream
+# Open-Systems-Pharmacology/rSharp#211) hits ~3-7% of full-suite runs, so waiting for
+# it to occur naturally is slow. This workflow force-hunts it: one dispatch fans out N
+# identical Windows-only R CMD check jobs, each with Windows Error Reporting crash-dump
+# capture. Any job that crashes uploads a crash-hunt-dumps-<n> artifact.
+#
+# Dispatch from this branch, e.g.:
+#   gh workflow run crash-hunt-1996.yaml --ref ci/windows-crash-dumps-1996 -f runs=20
+#
+# At ~5% crash probability per run: 10 runs ≈ 40%, 20 runs ≈ 64%, 40 runs ≈ 87%
+# chance of catching at least one dump. max-parallel is capped so the hunt does not
+# starve other CI jobs of Windows runners.
+
+name: Crash hunt (#1996)
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: 'Number of Windows check runs to fan out'
+        required: false
+        type: number
+        default: 20
+
+permissions: read-all
+
+jobs:
+  generate-matrix:
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_UBUNTU || 'ubuntu-latest' }}
+    outputs:
+      runs: ${{ steps.gen.outputs.runs }}
+    steps:
+      - id: gen
+        run: echo "runs=$(jq -cn "[range(1; ${{ inputs.runs }} + 1)]")" >> "$GITHUB_OUTPUT"
+
+  hunt:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        run: ${{ fromJSON(needs.generate-matrix.outputs.runs) }}
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}
+    name: Hunt run ${{ matrix.run }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup R environment
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        with:
+          setup-pandoc: 'true'
+          extra-packages: |
+            rcmdcheck
+
+      - name: Enable Windows crash dump capture
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'crashdumps'
+          New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+          $wer = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
+          New-Item -Path "$wer\LocalDumps" -Force | Out-Null
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpFolder -Value $dumpDir -Type ExpandString
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
+          Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--no-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          error-on: 'c("error")'
+
+      - name: Upload crash dumps
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-hunt-dumps-${{ matrix.run }}
+          path: ${{ env.CRASH_DUMP_DIR }}/*.dmp
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/crash-hunt-1996.yaml
+++ b/.github/workflows/crash-hunt-1996.yaml
@@ -57,10 +57,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Mirror the PR-shape check job (R-CMD-check-build.yaml as called by
+      # pull-request.yaml): same setup inputs and same check flags, so each hunt run
+      # exercises everything a PR check does — tests AND vignette execution.
       - name: Setup R environment
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
+          r-version: release
           setup-pandoc: 'true'
+          dotnet-version: '8.0.x'
           extra-packages: |
             rcmdcheck
 
@@ -80,8 +85,9 @@ jobs:
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--no-vignettes")'
-          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          upload-snapshots: true
+          args: 'c("--no-manual")'
+          build_args: 'c("--no-manual")'
           error-on: 'c("error")'
 
       - name: Upload crash dumps

--- a/.github/workflows/crash-hunt-1996.yaml
+++ b/.github/workflows/crash-hunt-1996.yaml
@@ -80,7 +80,20 @@ jobs:
           Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
           Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
           Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          # GitHub runner images ship with WER reporting disabled, which also disables
+          # LocalDumps collection (observed: a 0xC0000005 crash left no dump). Re-enable it.
+          Set-ItemProperty -Path $wer -Name Disabled -Value 0 -Type DWord
+          $werPolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'
+          if (Test-Path $werPolicy) { Set-ItemProperty -Path $werPolicy -Name Disabled -Value 0 -Type DWord }
+          try { Set-Service WerSvc -StartupType Manual } catch {}
           "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # Belt and braces: the crashing R worker hosts CoreCLR (rSharp), whose
+          # unhandled-exception filter can terminate the process before WER runs.
+          # With these set, the runtime writes its own full dump on any fatal exception,
+          # independent of WER. %p expands to the crashing PID.
+          "DOTNET_DbgEnableMiniDump=1" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DOTNET_DbgMiniDumpType=4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DOTNET_DbgMiniDumpName=$dumpDir\coreclr.%p.dmp" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,7 +19,9 @@ jobs:
   R-CMD-Check:
     needs: [sync-remotes]
     if: ${{ !cancelled() }} # a skipped fork-PR sync must not block the check
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+    # TEMPORARY (#1996): local copy of the shared R-CMD-check-build workflow that
+    # captures Windows crash dumps. Revert to the @main workflow once resolved.
+    uses: ./.github/workflows/R-CMD-check-build-crashdumps.yaml
 
   test-coverage:
     needs: [sync-remotes]

--- a/.github/workflows/update-renv-lockfile-crashdumps.yaml
+++ b/.github/workflows/update-renv-lockfile-crashdumps.yaml
@@ -117,7 +117,20 @@ jobs:
           Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
           Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
           Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          # GitHub runner images ship with WER reporting disabled, which also disables
+          # LocalDumps collection (observed: a 0xC0000005 crash left no dump). Re-enable it.
+          Set-ItemProperty -Path $wer -Name Disabled -Value 0 -Type DWord
+          $werPolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'
+          if (Test-Path $werPolicy) { Set-ItemProperty -Path $werPolicy -Name Disabled -Value 0 -Type DWord }
+          try { Set-Service WerSvc -StartupType Manual } catch {}
           "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # Belt and braces: the crashing R worker hosts CoreCLR (rSharp), whose
+          # unhandled-exception filter can terminate the process before WER runs.
+          # With these set, the runtime writes its own full dump on any fatal exception,
+          # independent of WER. %p expands to the crashing PID.
+          "DOTNET_DbgEnableMiniDump=1" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DOTNET_DbgMiniDumpType=4" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "DOTNET_DbgMiniDumpName=$dumpDir\coreclr.%p.dmp" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/update-renv-lockfile-crashdumps.yaml
+++ b/.github/workflows/update-renv-lockfile-crashdumps.yaml
@@ -1,0 +1,169 @@
+# TEMPORARY diagnostic copy — remove when #1996 is resolved.
+#
+# This is a local copy of
+# Open-Systems-Pharmacology/Workflows/.github/workflows/update-renv-lockfile.yaml@main
+# with two Windows-only steps added around "Check R package" ("Enable Windows crash
+# dump capture" / "Upload crash dumps"). It exists so we can collect a crash dump for
+# the intermittent 0xC0000005 access violation in Windows test runs (#1996) without
+# modifying the shared workflow used across the whole organisation.
+# Only update-renv-nightly.yaml points here.
+
+name: Update renv snapshot and check package
+
+on:
+  workflow_call:
+    inputs:
+      app-id:
+        type: string
+        required: true
+      os-matrix:
+        description: 'JSON array of OS names for the test matrix. Defaults to all three platforms.'
+        required: false
+        type: string
+        default: >-
+          ["${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}",
+          "${{ vars.GHA_DEFAULT_RUNNER_UBUNTU || 'ubuntu-latest' }}",
+          "${{ vars.GHA_DEFAULT_RUNNER_MACOS || 'macos-latest' }}"]
+    secrets:
+      private-key:
+        required: true
+
+jobs:
+  update-renv-lock:
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_UBUNTU || 'ubuntu-latest' }}
+    name: Update renv.lock
+    env:
+      GITHUB_PAT: ${{ github.token }}
+    outputs:
+      lockfile-changed: ${{ steps.check-changes.outputs.changed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Update project dependencies and snapshot lockfile
+        shell: Rscript {0}
+        run: |
+          install.packages("renv")
+          renv::install(prompt = FALSE, lock = TRUE)
+
+      - name: Check if renv.lock changed
+        id: check-changes
+        run: |
+          if [ -z "$(git status --porcelain -- renv.lock)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "renv.lock is unchanged, skipping downstream jobs."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "renv.lock has been updated."
+            git diff renv.lock
+          fi
+
+      - name: Upload updated renv.lock
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: renv-lock
+          path: renv.lock
+          retention-days: 1
+
+  test-on-platforms:
+    needs: update-renv-lock
+    if: needs.update-renv-lock.outputs.lockfile-changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.os-matrix) }}
+    runs-on: ${{ matrix.os }}
+    name: Test on ${{ matrix.os }}
+    env:
+      GITHUB_PAT: ${{ github.token }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Download updated renv.lock
+        uses: actions/download-artifact@v8
+        with:
+          name: renv-lock
+          path: .
+
+      - name: Setup R environment
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        with:
+          setup-pandoc: 'true'
+          extra-packages: |
+            rcmdcheck
+
+      # OSP R packages intermittently crash with an access violation (0xC0000005) on
+      # Windows runners (Open-Systems-Pharmacology/OSPSuite-R#1996). Register a
+      # machine-wide Windows Error Reporting LocalDumps key so any process that
+      # crashes during the check writes a full dump, uploaded below on failure.
+      - name: Enable Windows crash dump capture
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'crashdumps'
+          New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+          $wer = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
+          New-Item -Path "$wer\LocalDumps" -Force | Out-Null
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpFolder -Value $dumpDir -Type ExpandString
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
+          Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--no-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          error-on: 'c("error")'
+
+      - name: Upload crash dumps
+        if: failure() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-dumps-${{ matrix.os }}
+          path: ${{ env.CRASH_DUMP_DIR }}/*.dmp
+          if-no-files-found: ignore
+          retention-days: 7
+
+  commit-renv-lock:
+    needs: [update-renv-lock, test-on-platforms]
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_UBUNTU || 'ubuntu-latest' }}
+    if: needs.update-renv-lock.outputs.lockfile-changed == 'true' && needs.test-on-platforms.result == 'success'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate token from GitHub App
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.private-key }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download updated renv.lock
+        uses: actions/download-artifact@v8
+        with:
+          name: renv-lock
+          path: .
+
+      - name: Commit renv.lock if changed
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: '🤖 Update renv.lock [skip actions]'
+          default_author: github_actions
+          add: 'renv.lock'

--- a/.github/workflows/update-renv-nightly.yaml
+++ b/.github/workflows/update-renv-nightly.yaml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   update-renv-nightly:
-    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/update-renv-lockfile.yaml@main
+    # TEMPORARY (#1996): local copy of the shared update-renv-lockfile workflow that
+    # captures Windows crash dumps. Revert to the @main workflow once resolved.
+    uses: ./.github/workflows/update-renv-lockfile-crashdumps.yaml
     with:
       app-id: ${{ vars.VERSION_BUMPER_APPID }}
     secrets:


### PR DESCRIPTION
_**Maybe we don't even need to merge this - if we run the steps and get a crash dump.**_

We are still seeing occasional access violation crashes on Windows. This will capture dumps for analysis when a crash occurs

Removal of the temporary copies is tracked in #1998: once rSharp#211 is fixed, revert the two callers to `@main` and delete the copies. Both copies and both call sites carry `TEMPORARY (#1996)` comments.

## Notes for review

- Full dumps rather than minidumps: the suspected cause is heap/GC-state corruption in native code, and a stack-only minidump would likely show the corruption site without the context to attribute it.
- A full dump contains the job's process memory. The only secret in these jobs' environment is the run-scoped `GITHUB_TOKEN`, which expires when the run completes; retention is capped at 7 days.
- The PR checks on this very PR already exercise the local `R-CMD-check-build-crashdumps.yaml` end-to-end (the "Enable Windows crash dump capture" step passed on the Windows runner).

Refs #1996, #1998, Open-Systems-Pharmacology/rSharp#211

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows-focused “crash hunt” workflow to run multiple package checks in parallel.
* **Tests**
  * Enhanced Windows package checks with automatic crash-dump collection and artifact upload on failures.
  * Updated validation and nightly workflows to use the enhanced diagnostic checks.
* **Chores**
  * Improved automated `renv.lock` update flow: regenerate locks, run checks, and commit updated lockfiles when changes occur and tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->