### PR TITLE
Avoid eval() when building the y2axis aes mapping

### DIFF
--- a/R/plot-with-ospsuite-plots.R
+++ b/R/plot-with-ospsuite-plots.R
@@ -1275,7 +1275,7 @@ plotQuantileQuantilePlot <- function(
   if (any(names(metaData) %in% "y2")) {
     y2UnitValue <- metaData[["y2"]][["unit"]]
     mapping <- structure(
-      c(mapping, eval(bquote(ggplot2::aes(y2axis = yUnit == .(y2UnitValue))))),
+      c(mapping, ggplot2::aes(y2axis = yUnit == !!y2UnitValue)),
       class = "uneval"
     )
   }


### PR DESCRIPTION
Fixes #1976

## What

Replaces the `eval(bquote(...))` construction of the secondary-y-axis aesthetic in `.getMappingForTimeprofiles()` with rlang `!!`-injection, which `ggplot2::aes()` supports natively:

```r
# before
eval(bquote(ggplot2::aes(y2axis = yUnit == .(y2UnitValue))))
# after
ggplot2::aes(y2axis = yUnit == !!y2UnitValue)
```

## Why

The static-analysis finding in #1976 (CWE-95) flagged the `eval()` call. It was already non-exploitable — `bquote(.())` inserts the unit string as a literal value, never parsed as code — but the `eval()` is unnecessary ceremony: `!!` inlines the value into the captured expression the same way, keeping the mapping independent of the enclosing environment, without any `eval()` for scanners to flag.

## Verification

- The old and new forms produce identical quosure expressions (`yUnit == "mg/l"`) and identical results when evaluated against data.
- `testthat::test_file("tests/testthat/test-plot-with-ospsuite-plots.R")` (which covers the y2 mapping path): `FAIL 0 | WARN 0 | PASS 93`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secondary-axis plot handling to ensure data is mapped correctly when units match the secondary axis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->