### PR TITLE
Fixes #1819 separate unitConverter from extractMostFrequentUnit

### DIFF
--- a/R/utilities-data-combined.R
+++ b/R/utilities-data-combined.R
@@ -78,8 +78,11 @@ convertUnits <- function(dataCombined, xUnit = NULL, yUnit = NULL) {
   # Extract combined data frame
   combinedData <- dataCombined$toDataFrame()
 
+  xTargetUnit <- xUnit %||% .extractMostFrequentUnit(combinedData, "xUnit")
+  yTargetUnit <- yUnit %||% .extractMostFrequentUnit(combinedData, "yUnit")
+
   # Getting all units on the same scale
-  combinedData <- .unitConverter(combinedData, xUnit, yUnit)
+  combinedData <- .unitConverter(combinedData, xTargetUnit, yTargetUnit)
 
   return(combinedData)
 }
@@ -312,7 +315,9 @@ calculateResiduals <- function(
   }
 
   # Getting all datasets to have the same units.
-  combinedData <- .unitConverter(combinedData, xUnit, yUnit)
+  xTargetUnit <- xUnit %||% .extractMostFrequentUnit(combinedData, "xUnit")
+  yTargetUnit <- yUnit %||% .extractMostFrequentUnit(combinedData, "yUnit")
+  combinedData <- .unitConverter(combinedData, xTargetUnit, yTargetUnit)
 
   # Create observed versus simulated paired data using interpolation for each
   # grouping level and combine the resulting data frames in a row-wise manner.

--- a/R/utilities-data-combined.R
+++ b/R/utilities-data-combined.R
@@ -21,10 +21,10 @@
 #'
 #' @param dataCombined A single instance of `DataCombined` class.
 #' @param xUnit,yUnit Target units for `xValues` and `yValues`, respectively. If
-#'   not specified (`NULL`), first of the existing units in the respective
-#'   columns (`xUnit` and `yUnit`) will be selected as the common unit. For
-#'   available dimensions and units, see `ospsuite::ospDimensions` and
-#'   `ospsuite::ospUnits`, respectively.
+#'   not specified (`NULL`), the most frequently occurring unit in the
+#'   respective column is used, with observed-data units preferred over
+#'   simulated when both are present. For available dimensions and units, see
+#'   `ospsuite::ospDimensions` and `ospsuite::ospUnits`, respectively.
 #'
 #' @return
 #'
@@ -259,9 +259,10 @@ addResidualColumn <- function(
 #'   (log(simulated) - log(observed)), or `"ratio"` for the ratio of observed
 #'   to simulated (observed / simulated).
 #' @param xUnit,yUnit Target units for `xValues` and `yValues`, respectively. If
-#'   not specified (`NULL`), the first existing unit in the respective
-#'   columns will be selected as the common unit. For available dimensions
-#'   and units, see `ospsuite::ospDimensions` and `ospsuite::ospUnits`.
+#'   not specified (`NULL`), the most frequently occurring unit in the
+#'   respective column is used, with observed-data units preferred over
+#'   simulated when both are present. For available dimensions and units, see
+#'   `ospsuite::ospDimensions` and `ospsuite::ospUnits`.
 #'
 #' @return
 #' A tibble (data frame) containing paired observed-simulated data with calculated

--- a/R/utilities-plotting.R
+++ b/R/utilities-plotting.R
@@ -237,7 +237,7 @@
 #'   molWeight = c(10, 10, 20, 20, 10, 10)
 #' )
 #'
-#' df <- ospsuite:::.unitConverter(df)
+#' df <- ospsuite:::.unitConverter(df, xUnit = "min", yUnit = "mol/ml")
 #'
 #' ospsuite:::.createAxesLabels(df, tlf::TimeProfilePlotConfiguration$new())
 #'

--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -544,8 +544,14 @@ ospUnits <- NULL
 #' ospsuite:::.unitConverter(df, xUnit = ospUnits$Time$s, yUnit = ospUnits$Amount$mmol)
 #' @keywords internal
 .unitConverter <- function(data, xUnit, yUnit) {
-  # No validation of inputs for this non-exported function.
-  # All validation will take place in the `DataCombined` class itself.
+  validateIsOfType(data, "data.frame", nullAllowed = FALSE)
+  # isSupportedUnit() calls validateIsString() internally, rejecting NULL/non-string
+  if (!isSupportedUnit(xUnit)) {
+    stop(messages$errorUnitNotSupported(xUnit, "unknown"))
+  }
+  if (!isSupportedUnit(yUnit)) {
+    stop(messages$errorUnitNotSupported(yUnit, "unknown"))
+  }
 
   # target units --------------------------
   # Rename `x/yUnit`` as `x/yTargetUnit` to prevent issues with 

--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -547,18 +547,6 @@ ospUnits <- NULL
   # No validation of inputs for this non-exported function.
   # All validation will take place in the `DataCombined` class itself.
 
-  # early return --------------------------
-
-  # *DO NOT* use short-circuiting `&&` logical operator here.
-  if (
-    length(unique(data$xUnit)) == 1L &
-      data$xUnit[[1L]] == xUnit &
-      length(unique(data$yUnit)) == 1L &
-      data$yUnit[[1L]] == yUnit
-  ) {
-    return(data)
-  }
-
   # target units --------------------------
   # Rename `x/yUnit`` as `x/yTargetUnit` to prevent issues with 
   # data.table column names being the same name as variables
@@ -588,7 +576,7 @@ ospUnits <- NULL
     (any(colnames(data) == "yErrorValues")) &&
       !(any(colnames(data) == "yErrorUnit"))
   ) {
-    data <- dplyr::mutate(data, yErrorUnit = yUnit)
+    data <- dplyr::mutate(data, yErrorUnit = yTargetUnit)
   }
 
   # unit conversions --------------------------
@@ -715,77 +703,6 @@ ospUnits <- NULL
 #' @keywords internal
 .removeEmptyDataFrame <- function(x) {
   purrr::keep(x, function(data) nrow(data) > 0L)
-}
-
-
-#' @keywords internal
-#' @noRd
-.xUnitConverter <- function(xData, xTargetUnit) {
-  xData$xValues <- toUnit(
-    quantityOrDimension = xData$xDimension[[1]],
-    values = xData$xValues,
-    targetUnit = xTargetUnit,
-    sourceUnit = xData$xUnit[[1]]
-  )
-
-  xData$xUnit <- xTargetUnit
-
-  return(xData)
-}
-
-#' @keywords internal
-#' @noRd
-.yUnitConverter <- function(yData, yTargetUnit) {
-  yData$yValues <- toUnit(
-    quantityOrDimension = yData$yDimension[[1]],
-    values = yData$yValues,
-    targetUnit = yTargetUnit,
-    sourceUnit = yData$yUnit[[1]],
-    molWeight = yData$molWeight[[1]],
-    molWeightUnit = ospUnits$`Molecular weight`$`g/mol`
-  )
-
-  if (any(colnames(yData) == "lloq")) {
-    yData$lloq <- toUnit(
-      quantityOrDimension = yData$yDimension[[1]],
-      values = yData$lloq,
-      targetUnit = yTargetUnit,
-      sourceUnit = yData$yUnit[[1]],
-      molWeight = yData$molWeight[[1]],
-      molWeightUnit = ospUnits$`Molecular weight`$`g/mol`
-    )
-  }
-
-  yData$yUnit <- yTargetUnit
-
-  return(yData)
-}
-
-#' @keywords internal
-#' @noRd
-.yErrorUnitConverter <- function(yData, yTargetUnit) {
-  # If error type is geometric, conversion of `yValues` to different units
-  # should not trigger conversion of error values (and units)
-  if (
-    any(colnames(yData) == "yErrorType") &&
-      !is.na(unique(yData$yErrorType)) &&
-      unique(yData$yErrorType) == DataErrorType$GeometricStdDev
-  ) {
-    return(yData)
-  }
-
-  yData$yErrorValues <- toUnit(
-    quantityOrDimension = yData$yDimension[[1]],
-    values = yData$yErrorValues,
-    targetUnit = yTargetUnit,
-    sourceUnit = yData$yErrorUnit[[1]],
-    molWeight = yData$molWeight[[1]],
-    molWeightUnit = ospUnits$`Molecular weight`$`g/mol`
-  )
-
-  yData$yErrorUnit <- yTargetUnit
-
-  return(yData)
 }
 
 

--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -576,7 +576,7 @@ ospUnits <- NULL
     (any(colnames(data) == "yErrorValues")) &&
       !(any(colnames(data) == "yErrorUnit"))
   ) {
-    data <- dplyr::mutate(data, yErrorUnit = yTargetUnit)
+    data <- dplyr::mutate(data, yErrorUnit = yUnit)
   }
 
   # unit conversions --------------------------

--- a/R/utilities-units.R
+++ b/R/utilities-units.R
@@ -511,7 +511,10 @@ ospUnits <- NULL
 #' Convert a data frame to common units
 #'
 #' @param data A data frame (or a tibble) from `DataCombined$toDataFrame()`.
-#' @inheritParams convertUnits
+#' @param xUnit Target unit for `xValues`. Use `.extractMostFrequentUnit(data, "xUnit")`
+#'   to select the most frequent unit from the data.
+#' @param yUnit Target unit for `yValues`. Use `.extractMostFrequentUnit(data, "yUnit")`
+#'   to select the most frequent unit from the data.
 #'
 #' @seealso toUnit
 #'
@@ -531,45 +534,36 @@ ospUnits <- NULL
 #'   molWeight = c(10, 10, 20, 20, 20, 10)
 #' ))
 #'
-#' # default conversion
-#' ospsuite:::.unitConverter(df)
+#' # pick target units from data, then convert
+#' ospsuite:::.unitConverter(df,
+#'   xUnit = ospsuite:::.extractMostFrequentUnit(df, "xUnit"),
+#'   yUnit = ospsuite:::.extractMostFrequentUnit(df, "yUnit")
+#' )
 #'
-#' # customizing conversion with specified unit(s)
-#' ospsuite:::.unitConverter(df, xUnit = ospUnits$Time$h)
-#' ospsuite:::.unitConverter(df, yUnit = ospUnits$Mass$kg)
+#' # explicit units
 #' ospsuite:::.unitConverter(df, xUnit = ospUnits$Time$s, yUnit = ospUnits$Amount$mmol)
 #' @keywords internal
-.unitConverter <- function(data, xUnit = NULL, yUnit = NULL) {
+.unitConverter <- function(data, xUnit, yUnit) {
   # No validation of inputs for this non-exported function.
   # All validation will take place in the `DataCombined` class itself.
 
   # early return --------------------------
 
-  # Return early if there are only unique units present in the provided data and
-  # `xUnit` and `yUnit` arguments are `NULL`. This helps avoid expensive and
-  # redundant computations.
-  #
   # *DO NOT* use short-circuiting `&&` logical operator here.
   if (
     length(unique(data$xUnit)) == 1L &
-      is.null(xUnit) &
+      data$xUnit[[1L]] == xUnit &
       length(unique(data$yUnit)) == 1L &
-      is.null(yUnit)
+      data$yUnit[[1L]] == yUnit
   ) {
     return(data)
   }
 
   # target units --------------------------
-
-  # The observed and simulated data should have the same units for
-  # visual/graphical comparison.
-  #
-  # Therefore, if target units are not specified by the user, we need to choose
-  # one ourselves. The most frequent units will be selected: one for X-axis, and
-  # one for Y-axis. If multiple units are tied in terms of their frequency, the
-  # first will be selected.
-  xTargetUnit <- xUnit %||% .extractMostFrequentUnit(data, unitColumn = "xUnit")
-  yTargetUnit <- yUnit %||% .extractMostFrequentUnit(data, unitColumn = "yUnit")
+  # Rename `x/yUnit`` as `x/yTargetUnit` to prevent issues with 
+  # data.table column names being the same name as variables
+  xTargetUnit <- xUnit
+  yTargetUnit <- yUnit
 
   # Strategy --------------------------
 
@@ -602,7 +596,7 @@ ospUnits <- NULL
   # Convert to data.table for efficient in-place grouped operations.
   # `as.data.table()` creates a copy when the input is a tibble/data.frame,
   # so the caller's object is never modified by reference.
-  data <- as.data.table(data)
+  data <- data.table::as.data.table(data)
 
   # xUnit: convert xValues in-place, grouped by (xDimension, xUnit)
   data[,

--- a/man/calculateResiduals.Rd
+++ b/man/calculateResiduals.Rd
@@ -17,9 +17,10 @@ calculation.  Accepted values are \code{"lin"} / \code{"linear"} for linear resi
 to simulated (observed / simulated).}
 
 \item{xUnit, yUnit}{Target units for \code{xValues} and \code{yValues}, respectively. If
-not specified (\code{NULL}), the first existing unit in the respective
-columns will be selected as the common unit. For available dimensions
-and units, see \code{ospsuite::ospDimensions} and \code{ospsuite::ospUnits}.}
+not specified (\code{NULL}), the most frequently occurring unit in the
+respective column is used, with observed-data units preferred over
+simulated when both are present. For available dimensions and units, see
+\code{ospsuite::ospDimensions} and \code{ospsuite::ospUnits}.}
 }
 \value{
 A tibble (data frame) containing paired observed-simulated data with calculated

--- a/man/convertUnits.Rd
+++ b/man/convertUnits.Rd
@@ -10,10 +10,10 @@ convertUnits(dataCombined, xUnit = NULL, yUnit = NULL)
 \item{dataCombined}{A single instance of \code{DataCombined} class.}
 
 \item{xUnit, yUnit}{Target units for \code{xValues} and \code{yValues}, respectively. If
-not specified (\code{NULL}), first of the existing units in the respective
-columns (\code{xUnit} and \code{yUnit}) will be selected as the common unit. For
-available dimensions and units, see \code{ospsuite::ospDimensions} and
-\code{ospsuite::ospUnits}, respectively.}
+not specified (\code{NULL}), the most frequently occurring unit in the
+respective column is used, with observed-data units preferred over
+simulated when both are present. For available dimensions and units, see
+\code{ospsuite::ospDimensions} and \code{ospsuite::ospUnits}, respectively.}
 }
 \value{
 A data frame with measurement columns transformed to have common units.

--- a/man/dot-createAxesLabels.Rd
+++ b/man/dot-createAxesLabels.Rd
@@ -38,7 +38,7 @@ df <- dplyr::tibble(
   molWeight = c(10, 10, 20, 20, 10, 10)
 )
 
-df <- ospsuite:::.unitConverter(df)
+df <- ospsuite:::.unitConverter(df, xUnit = "min", yUnit = "mol/ml")
 
 ospsuite:::.createAxesLabels(df, tlf::TimeProfilePlotConfiguration$new())
 

--- a/man/dot-unitConverter.Rd
+++ b/man/dot-unitConverter.Rd
@@ -4,16 +4,16 @@
 \alias{.unitConverter}
 \title{Convert a data frame to common units}
 \usage{
-.unitConverter(data, xUnit = NULL, yUnit = NULL)
+.unitConverter(data, xUnit, yUnit)
 }
 \arguments{
 \item{data}{A data frame (or a tibble) from \code{DataCombined$toDataFrame()}.}
 
-\item{xUnit, yUnit}{Target units for \code{xValues} and \code{yValues}, respectively. If
-not specified (\code{NULL}), first of the existing units in the respective
-columns (\code{xUnit} and \code{yUnit}) will be selected as the common unit. For
-available dimensions and units, see \code{ospsuite::ospDimensions} and
-\code{ospsuite::ospUnits}, respectively.}
+\item{xUnit}{Target unit for \code{xValues}. Use \code{.extractMostFrequentUnit(data, "xUnit")}
+to select the most frequent unit from the data.}
+
+\item{yUnit}{Target unit for \code{yValues}. Use \code{.extractMostFrequentUnit(data, "yUnit")}
+to select the most frequent unit from the data.}
 }
 \description{
 Convert a data frame to common units
@@ -34,12 +34,13 @@ Convert a data frame to common units
   molWeight = c(10, 10, 20, 20, 20, 10)
 ))
 
-# default conversion
-ospsuite:::.unitConverter(df)
+# pick target units from data, then convert
+ospsuite:::.unitConverter(df,
+  xUnit = ospsuite:::.extractMostFrequentUnit(df, "xUnit"),
+  yUnit = ospsuite:::.extractMostFrequentUnit(df, "yUnit")
+)
 
-# customizing conversion with specified unit(s)
-ospsuite:::.unitConverter(df, xUnit = ospUnits$Time$h)
-ospsuite:::.unitConverter(df, yUnit = ospUnits$Mass$kg)
+# explicit units
 ospsuite:::.unitConverter(df, xUnit = ospUnits$Time$s, yUnit = ospUnits$Amount$mmol)
 }
 \seealso{

--- a/tests/testthat/test-utilities-plotting.R
+++ b/tests/testthat/test-utilities-plotting.R
@@ -25,7 +25,7 @@ test_that("It returns `NULL` when data frame is empty", {
 
 test_that("It replaces 'Concentration (molar)' and 'Concentration (mass)' by 'Concentration' in plot axis labels", {
   labels <- .createAxesLabels(
-    .unitConverter(df),
+    .unitConverter(df, xUnit = "min", yUnit = "mol/ml"),
     TimeProfilePlotConfiguration$new()
   )
 
@@ -59,7 +59,10 @@ test_that("It works correctly when multiple dimensions are present and max frequ
 
   df <- myCombDat$toDataFrame()
   labs <- .createAxesLabels(
-    .unitConverter(df),
+    .unitConverter(df,
+      xUnit = .extractMostFrequentUnit(df, "xUnit"),
+      yUnit = .extractMostFrequentUnit(df, "yUnit")
+    ),
     tlf::TimeProfilePlotConfiguration$new()
   )
 

--- a/tests/testthat/test-utilities-units.R
+++ b/tests/testthat/test-utilities-units.R
@@ -285,13 +285,13 @@ dfEarly <- dplyr::tibble(
   molWeight = 10
 )
 
-test_that("returns early if there are only unique units and arguments are `NULL`", {
-  expect_equal(dfEarly, .unitConverter(dfEarly))
+test_that("returns early if there are only unique units", {
+  expect_equal(dfEarly, .unitConverter(dfEarly, xUnit = "min", yUnit = "%"))
 })
 
 # default conversion -------------------
 
-dfConvert <- .unitConverter(df)
+dfConvert <- .unitConverter(df, xUnit = "min", yUnit = "%")
 
 test_that("defaults for .unitConverter update xValues column as expected", {
   expect_equal(dfConvert$xValues, df$xValues)
@@ -322,7 +322,7 @@ test_that("defaults for .unitConverter don't introduce yUnitError column if not 
 
 # only `xUnit` -------------------
 
-dfXConvert <- .unitConverter(df, xUnit = ospUnits$Time$h)
+dfXConvert <- .unitConverter(df, xUnit = ospUnits$Time$h, yUnit = "%")
 
 test_that(".unitConverter converts xValues column as expected", {
   expect_equal(dfXConvert$xValues, df$xValues / 60) # 1 hour = 60 minutes
@@ -334,7 +334,7 @@ test_that(".unitConverter updates xUnit column as expected", {
 
 # only `yUnit` -------------------
 
-dfYConvert <- .unitConverter(df, yUnit = ospUnits$Fraction$`%`)
+dfYConvert <- .unitConverter(df, xUnit = "min", yUnit = ospUnits$Fraction$`%`)
 
 test_that(".unitConverter converts yValues as expected", {
   expect_equal(dfYConvert$yValues[1], df$yValues[1] * 100)
@@ -378,7 +378,7 @@ dfMW <- dplyr::tibble(
   random = "bla" # only for testing that the function doesn't remove other columns
 )
 
-dfMWConvert <- .unitConverter(dfMW, yUnit = ospUnits$Mass$g)
+dfMWConvert <- .unitConverter(dfMW, xUnit = "min", yUnit = ospUnits$Mass$g)
 
 test_that(".unitConverter updates yValues with molecular weight when dimension is amount", {
   expect_equal(
@@ -411,8 +411,8 @@ test_that(".unitConverter doesn't change dimensions under any circumstances", {
 
 # error units -------------------
 
-dfErrorConvert <- .unitConverter(dfError)
-dfYErrorConvert <- .unitConverter(dfError, yUnit = ospUnits$Fraction$`%`)
+dfErrorConvert <- .unitConverter(dfError, xUnit = "min", yUnit = "%")
+dfYErrorConvert <- .unitConverter(dfError, xUnit = "min", yUnit = ospUnits$Fraction$`%`)
 
 test_that(".unitConverter changes error units as well - defaults", {
   expect_equal(unique(dfErrorConvert$yErrorUnit), "%")
@@ -436,7 +436,7 @@ test_that("Correct conversion for yValues having the same unit but different MW"
     ),
     molWeight = c(10, 10, 20)
   )
-  dfConvert <- .unitConverter(df, yUnit = "g")
+  dfConvert <- .unitConverter(df, xUnit = "min", yUnit = "g")
 
   expect_equal(dfConvert$yValues, c(10, 10, 20))
 })
@@ -456,7 +456,7 @@ dfNA <- dplyr::tibble(
   molWeight = c(NA, NA, NA, 129.1636, 129.1636, 129.1636)
 )
 
-dfNAConvert <- .unitConverter(dfNA)
+dfNAConvert <- .unitConverter(dfNA, xUnit = "min", yUnit = "")
 dfNAXYConvert <- .unitConverter(dfNA, xUnit = "h", yUnit = "")
 
 test_that("the order of rows is not changed", {
@@ -545,7 +545,7 @@ dfMolWeightNA <- dplyr::tibble(
 
 test_that("if molWeight is missing, an error is signaled if dimensions require them", {
   expect_error(
-    .unitConverter(dfMolWeightNA, yUnit = "mol"),
+    .unitConverter(dfMolWeightNA, xUnit = "min", yUnit = "mol"),
     "Molecular Weight not available."
   )
 })
@@ -566,12 +566,12 @@ dfErrorUnitMissing <- dplyr::tibble(
 
 test_that("if yErrorUnit is missing, error values are converted correctly", {
   expect_equal(
-    .unitConverter(dfErrorUnitMissing)$yErrorValues,
+    .unitConverter(dfErrorUnitMissing, xUnit = "min", yUnit = "%")$yErrorValues,
     dfErrorUnitMissing$yErrorValues
   )
 
   expect_equal(
-    .unitConverter(dfErrorUnitMissing, yUnit = "")$yErrorValues,
+    .unitConverter(dfErrorUnitMissing, xUnit = "min", yUnit = "")$yErrorValues,
     dfErrorUnitMissing$yErrorValues / 100
   )
 })
@@ -591,7 +591,7 @@ dfLloq <- dplyr::tibble(
   random = "bla" # test that function doesn't remove additional columns
 )
 
-dfMWConvert <- .unitConverter(dfLloq, yUnit = ospUnits$Mass$g)
+dfMWConvert <- .unitConverter(dfLloq, xUnit = "min", yUnit = ospUnits$Mass$g)
 
 test_that("it can convert lloq columns", {
   expect_equal(dfMWConvert$lloq, rep(10, 3))
@@ -615,7 +615,8 @@ dfWeek <- dplyr::tibble(
 
 dfWeekConvert <- .unitConverter(
   dfWeek,
-  xUnit = ospUnits$Time$`week(s)`
+  xUnit = ospUnits$Time$`week(s)`,
+  yUnit = "%"
 )
 
 test_that("it can convert time to weeks", {
@@ -661,7 +662,7 @@ dfGeomError <- dplyr::tibble(
   molWeight = 225.21
 )
 
-dfGeomErrorConvert <- .unitConverter(dfGeomError, yUnit = "µmol/l")
+dfGeomErrorConvert <- .unitConverter(dfGeomError, xUnit = "h", yUnit = "µmol/l")
 
 test_that("It shouldn't convert geometric error values or units, only `yValues`", {
   expect_equal(
@@ -711,6 +712,7 @@ dfMixedError <- dplyr::tibble(
 
 dfMixedErrorConvert <- .unitConverter(
   dfMixedError,
+  xUnit = "min",
   yUnit = ospUnits$Fraction$`%`
 )
 
@@ -744,7 +746,7 @@ dfConc <- dplyr::tibble(
   molWeight = 10
 )
 
-dfConcConvert <- .unitConverter(dfConc)
+dfConcConvert <- .unitConverter(dfConc, xUnit = "h", yUnit = "mg/l")
 
 test_that("it retains multiple concentration dimensions", {
   expect_equal(unique(dfConcConvert$yDimension), concDims)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unit conversion automatically selects the most frequently used units when target units aren’t specified.
  - When tied, units from observed data are preferred over simulated-data units.
  - Explicitly provided units continue to be honored for conversions and plotting.

- **Bug Fixes**
  - Improved validation and consistency for unit conversion across supported data scenarios.

- **Documentation**
  - Updated guidance and examples to clarify automatic unit selection and explicit conversion options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->